### PR TITLE
Astroquery.mast.tesscut tutorial

### DIFF
--- a/notebooks/MAST/astroquery/astroquery-mast-cutouts/astroquery-mast-cutouts.ipynb
+++ b/notebooks/MAST/astroquery/astroquery-mast-cutouts/astroquery-mast-cutouts.ipynb
@@ -1,0 +1,585 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "71b41ab3",
+   "metadata": {},
+   "source": [
+    "# Creating Cutouts with `astroquery.mast`'s `Cutouts` Services"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64bfef79",
+   "metadata": {},
+   "source": [
+    "## Learning Goals\n",
+    "\n",
+    "By the end of this tutorial, you will:\n",
+    "* Learn about the 3 cutout services provided by MAST: TESSCut, HAPCut, and ZCut.\n",
+    "* Learn how to utilize `astroquery.mast`'s wrappers for the TESSCut and HAPCut services (`astroquery.mast.Tesscut` and `astroquery.mast.Hapcut`, respectively).\n",
+    "* Learn the functionalities provided by these `astroquery.mast` cutout service wrappers.\n",
+    "* Understand the available TESS products the `astroquery.mast.Tesscut` cutouts can be made from."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23fb7a92",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "The Mikulski Archive for Space Telescopes (MAST) provides a suite of cutout services for several space telescope missions and use-cases:\n",
+    "\n",
+    "* [<b>HAPCut Service</b>](https://mast.stsci.edu/hapcut/) : Generates cutouts out of [Hubble Advanced Products (HAPs)](https://outerspace.stsci.edu/display/HAdP/Improvements+in+HST+Astrometry) available in MAST.\n",
+    "* [<b>TESSCut Service</b>](https://mast.stsci.edu/tesscut/docs/index.html) : Generates cutouts out of TESS mission full frame images (namely [TESS-SPOC](https://heasarc.gsfc.nasa.gov/docs/tess/pipeline.html) and [TICA](https://archive.stsci.edu/hlsp/tica)).\n",
+    "* [<b>ZCut Service</b>](https://mast.stsci.edu/zcut/) : Generates cutouts out of MAST-supported deep field surveys (e.g. CANDELS, 3D-HST).\n",
+    "\n",
+    "Each of these services can be accessed through a standard GET request to their respective APIs, but they can also be accessed via the `astroquery.mast` module through their respective classes: `astroquery.mast.Hapcut`, `astroquery.mast.Tesscut` and `astroquery.mast.Zcut`. In this notebook, we will walk through two examples: one where we access the TESSCut service with `astroquery.mast.Tesscut`, and one where we access the HAPCut service with `astroquery.mast.Hapcut`. A separate notebook has already been made demonstrating how to access the ZCut service with `astroquery.mast.Zcut`, and is available [here](https://github.com/spacetelescope/mast_notebooks/blob/main/notebooks/astroquery/beginner_zcut/beginner_zcut.ipynb).\n",
+    "\n",
+    "The workflow for this notebook consists of:\n",
+    "\n",
+    "* [Example 1: Retrieve TESS Sectors & Cutouts with `astroquery.mast.Tesscut`](#Example-1:-Retrieve-TESS-Sectors-&-Cutouts-with-astroquery.mast.Tesscut)\n",
+    "    * [Example 1: Get Sector Information](#Example-1:-Get-Sector-Information)\n",
+    "    * [Example 1: Get Cutouts](#Example-1:-Get-Cutouts)\n",
+    "    * [Example 1: Download Cutouts](#Example-1:-Download-Cutouts)\n",
+    "* [Example 2: Retrieve HAP Cutouts with `astroquery.mast.Hapcut`](#Example-2:-Retrieve-HAP-Cutouts-with-astroquery.mast.Hapcut)\n",
+    "    * [Example 2: Get Cutouts](#Example-2:-Get-Cutouts)\n",
+    "    * [Example 2: Download Cutouts](#Example-2:-Download-Cutouts)\n",
+    "* [ZCut for Beginners with `astroquery.mast.Zcut`](#ZCut-for-Beginners-with-astroquery.mast.Zcut)\n",
+    "* [Resources](#Resources)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4356a440",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    "Below is a list of the packages used throughout this notebook, and their use-cases. Please ensure you have the recommended version of these packages installed on the environment this notebook has been launched in. See the `requirements.txt` file for recommended package versions.\n",
+    "\n",
+    "\n",
+    "* _astropy.units_ for unit conversion\n",
+    "* _matplotlib.pyplot_ for plotting data\n",
+    "* _astropy.coordinates SkyCoord_ for creating sky coordinate objects\n",
+    "* _astropy.io fits_ for accessing FITS files\n",
+    "* _astroquery.mast Hapcut_ and _Tesscut_ for retrieving and downloading the TESS FFIs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e62ffad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.units as u\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.io import fits\n",
+    "from astroquery.mast import Hapcut, Tesscut"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f77fc172",
+   "metadata": {},
+   "source": [
+    "----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "398dec71",
+   "metadata": {},
+   "source": [
+    "## Example 1: Retrieve TESS Sectors & Cutouts with `astroquery.mast.Tesscut`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01364258",
+   "metadata": {},
+   "source": [
+    "In this example we will work with target TIC 820148 and retrieve its sector information (the TESS sectors it lands on), as well as explore the 2 ways we can retrieve cutouts of this target from the corresponding sector observations. We will also explore the two types of calibrated full frame images that we can extract cutouts from (TESS-SPOC and TICA), and how to request cutouts from one or the other.\n",
+    "\n",
+    "Let's start by assigning the RA and Dec of our target to a `SkyCoord` object named `coords`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e9606df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Target TIC 820148\n",
+    "ra, dec = 135.068791070904, -4.93685127545661\n",
+    "coords = SkyCoord(ra*u.deg, dec*u.deg, frame='icrs')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b10595b",
+   "metadata": {},
+   "source": [
+    "### Example 1: Get Sector Information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70820a7d",
+   "metadata": {},
+   "source": [
+    "The next thing we want to do is find the sector observations that our target lands on. To do this, we will call the `get_sectors` method. \n",
+    "\n",
+    "There are two types of products you can retrieve sector information for: the TESS-SPOC FFIs and the TICA FFIs, both available in the MAST database. These products are FFIs calibrated by two separate pipelines, and are also delivered to MAST at a slightly different cadence. The TICA products are delivered up to 3 weeks sooner than their TESS-SPOC counterparts, so users working with time-sensitive data may want to opt for setting the `product` argument to TICA to request the TICA sector information. If the `product` argument is not called, it will default to retrieve sector information for TESS-SPOC.\n",
+    "\n",
+    "For this example, let's request for the sectors available for only the TICA FFIs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26b79fd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Tesscut.get_sectors(coordinates=coords, product='tica')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee59ed02",
+   "metadata": {},
+   "source": [
+    "It looks like our target lands on sector 34 and 61 observations for the TICA FFIs.\n",
+    "\n",
+    "**Note**: The TICA pipeline began processing sector observations from sector 27 onward, so observations for sectors 1-26 will not have any TICA cutouts available for download. Below we run the same example from above, but for TESS-SPOC products (`product` defaults to this when not explicitly called)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43e3ad8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Tesscut.get_sectors(coordinates=coords)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e80de839",
+   "metadata": {},
+   "source": [
+    "### Example 1: Get Cutouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bccb8890",
+   "metadata": {},
+   "source": [
+    "The next functionality we want to demonstrate is the `get_cutouts` functionality, which allows you to retrieve a list of unpacked FITS HDU lists for the cutouts requested of your target, for all the available sectors. This may take a while depending on how many sectors the cutouts are being retrieved from, and the size of the cutout. We recommend cutouts no larger than 30 pixels (or ~10.5 arcminutes) in either dimension. \n",
+    "\n",
+    "In the example below, we will request for `6 x 6` pixel cutouts, from all available sectors for TICA. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecdc00e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutouts = Tesscut.get_cutouts(coordinates=coords, product='tica', size=6)\n",
+    "cutouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1cd403e",
+   "metadata": {},
+   "source": [
+    "Keep in mind that when the `sector` keyword argument is not explicitly called, cutout HDU lists will be generated for all the sectors available for `product`. To select for only a single sector, you can use the sector information retrieved with `get_sectors`, and declare this with the `sector` argument like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92293729",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutouts = Tesscut.get_cutouts(coordinates=coords, product='tica', size=6, sector=34)\n",
+    "cutouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a9355f3",
+   "metadata": {},
+   "source": [
+    "And to confirm that we are retrieving cutouts from the correct sector, let's pull out the keyword value for keyword `SECTOR` in the primary header:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54aaefae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutouts[0][0].header['SECTOR']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91b4ebd6",
+   "metadata": {},
+   "source": [
+    "Next we will plot one of the FFI cutouts for sector 34. The cutouts data is in the BinTableHDU (Extension 1), and is stored under the `FLUX` table column. Let's display the first cutout in the table:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3b31a5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffi_cutout = cutouts[0][1].data['FLUX'][0]\n",
+    "\n",
+    "plt.imshow(ffi_cutout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25068c79",
+   "metadata": {},
+   "source": [
+    "Lastly, the software used to generate this cutout is available in the primary header under the `PROCVER` keyword, as well as the product, or `FFI_TYPE`, the cutouts were made from (TICA or SPOC)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3501c72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(cutouts[0][0].header.cards['PROCVER'])\n",
+    "print(cutouts[0][0].header.cards['FFI_TYPE'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2f0a01b",
+   "metadata": {},
+   "source": [
+    "### Example 1: Download Cutouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf3be82",
+   "metadata": {},
+   "source": [
+    "Users who want to store their requested TESS cutouts locally have the option to download them via the `download_cutouts` method. The call looks similar to the `get_cutouts` functionality, only the output product is an astropy table listing the location(s) of the downloaded cutout file(s). Users can declare the location of their download using the `path` argument; When `path` is not specified, the cutouts download in the current working directory by default. \n",
+    "\n",
+    "Let's make a `download_cutouts` request for `6 x 6` TICA cutouts of our target TIC 820148, for all sectors available for TICA:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60fa5388",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manifest = Tesscut.download_cutouts(coordinates=coords, product='tica', size=6)\n",
+    "manifest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac0ee15d",
+   "metadata": {},
+   "source": [
+    "Let's inspect the first cutout of the sector 34 cutout file like how we did in the `get_cutouts` example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c08641b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for file in manifest['Local Path']:\n",
+    "    if 's0034' in file:\n",
+    "        ffi_cutout = fits.getdata(file)['FLUX'][0]\n",
+    "        \n",
+    "plt.imshow(ffi_cutout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c91cd4d4",
+   "metadata": {},
+   "source": [
+    "**Note**: As of June 2023, TICA is not supported by TESSCut's moving targets feature, so any call to moving targets in any of the three functions demonstrated above while `product='TICA'` will return an `InvalidQueryError`. Let's demonstrate this by requesting TICA cutouts of moving target <i>Eleonora</i>:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0de1357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This cell will give an error if you uncomment the line below!\n",
+    "\n",
+    "#Tesscut.download_cutouts(objectname='Eleonora', moving_target=True, product='tica', size=6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ae4733e",
+   "metadata": {},
+   "source": [
+    "## Example 2: Retrieve HAP Cutouts with `astroquery.mast.Hapcut`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "453387bc",
+   "metadata": {},
+   "source": [
+    "The functionality for requesting HAP cutouts through `astroquery.mast` with HAPCut is very similar to that of TESSCut. For this example, we will request HAP cutouts for target M16 (the Eagle Nebula) observed with HST's Wide Field Camera 3 (WFC3) via program 13926."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ac0485b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coords = SkyCoord(\"274.6923395574 -13.83204435743\", unit='deg')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86d3026e",
+   "metadata": {},
+   "source": [
+    "Some notable differences between `astroquery.mast` communications with the HAPCut API and the TESSCut API that you will see in the following examples are: \n",
+    "* There is no `product` argument, as there is not more than one pipeline from which the HAPs are made.\n",
+    "* There is no `sector` argument, as sector observations are unique to the TESS mission. On that note: \n",
+    "* There is no `get_sectors` functionality. Only `get_cutouts` and `download_cutouts`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afab9eb9",
+   "metadata": {},
+   "source": [
+    "### Example 2: Get Cutouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfcf383a",
+   "metadata": {},
+   "source": [
+    "Let's begin with an example for `get_cutouts`. We'll request a larger cutout (`100 x 100` pixels), since the HST field of view is smaller than TESS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8af7896e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutouts = Hapcut.get_cutouts(coordinates=coords, size=100)\n",
+    "cutouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a327998",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the science array for one of the returned product cutouts. For WFC3, the science array is the `ImageHDU` in Extension 1:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3e45c4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(cutouts[2][1].data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc45ee86",
+   "metadata": {},
+   "source": [
+    "### Example 2: Download Cutouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b5482c9",
+   "metadata": {},
+   "source": [
+    "Lastly, let's take a look at the `download_cutouts` functionality for the HAPCut API using the same target. This is analogous to `Tesscut.download_cutouts` and the call will look pretty much the same:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab00225e",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "manifest = Hapcut.download_cutouts(coordinates=coords, size=100)\n",
+    "manifest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b1fc741",
+   "metadata": {},
+   "source": [
+    "Finally, let's plot the science results for the IR F110W observation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81674080",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for file in manifest['Local Path']:\n",
+    "    if 'ir_f110w' in file:\n",
+    "        data = fits.getdata(file, 1)\n",
+    "        \n",
+    "plt.imshow(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa63de38",
+   "metadata": {},
+   "source": [
+    "## ZCut for Beginners with `astroquery.mast.Zcut`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "925cb28b",
+   "metadata": {},
+   "source": [
+    "For users who would like to make cutouts out of deep field surveys, `astroquery.mast` can make communications with the ZCut API through `astroquery.mast.Zcut`. There is an existing notebook dedicated to demonstrating this functionality, which you can find in the `mast_notebooks` GitHub repository [here](https://github.com/spacetelescope/mast_notebooks/blob/main/notebooks/astroquery/beginner_zcut/beginner_zcut.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60933e3f",
+   "metadata": {},
+   "source": [
+    "## Resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "900f8f84",
+   "metadata": {},
+   "source": [
+    "The following is a list of resources that were referenced throughout the tutorial, as well as some additional references that you may find useful:\n",
+    "\n",
+    "* The [astroquery.mast Documentation](https://astroquery.readthedocs.io/en/latest/mast/mast.html)\n",
+    "* The [HAPCut Service Documentation](https://mast.stsci.edu/hapcut/)\n",
+    "* The [TESSCut Service Documentation](https://mast.stsci.edu/tesscut/docs/index.html)\n",
+    "* The [TESSCut Service UI](https://mast.stsci.edu/tesscut/)\n",
+    "* The [ZCut Service Documentation](https://mast.stsci.edu/zcut/)\n",
+    "* The [ZCut For Beginners](https://github.com/spacetelescope/mast_notebooks/blob/main/notebooks/astroquery/beginner_zcut/beginner_zcut.ipynb) Notebook Tutorial\n",
+    "* A Description of The [Hubble Advanced Products](https://outerspace.stsci.edu/display/HAdP/Improvements+in+HST+Astrometry) (HAPs)\n",
+    "* The [TESS-SPOC Pipeline](https://heasarc.gsfc.nasa.gov/docs/tess/pipeline.html)\n",
+    "* The [TICA HLSP Pipeline](https://archive.stsci.edu/hlsp/tica)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b11a18d1",
+   "metadata": {},
+   "source": [
+    "## Citations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e08c4c6",
+   "metadata": {},
+   "source": [
+    "If you use any of astroquery's tools for published research, or any of the cutout services, please cite the authors. Follow these links for more information about citing astroquery and astrocut (the cutout services' source code):\n",
+    "\n",
+    "* [Citing `astroquery`](https://github.com/astropy/astroquery/blob/main/astroquery/CITATION)\n",
+    "* [Citing `astrocut`](https://ui.adsabs.harvard.edu/abs/2019ascl.soft05007B/abstract)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f42d2e0",
+   "metadata": {},
+   "source": [
+    "## About this Notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d30218da",
+   "metadata": {},
+   "source": [
+    "If you have comments or questions on this notebook, please contact us through the Archive Help Desk e-mail at archive@stsci.edu.\n",
+    "\n",
+    "<b>Author(s)</b>: Jenny V. Medina <br>\n",
+    "<b>Keyword(s)</b>: Tutorial, TESS, TICA, SPOC, HAP, hubble, astroquery, cutouts, ffi, tesscut, hapcut, zcut <br>\n",
+    "<b>Last Updated</b>: Jun 2023"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/MAST/astroquery/astroquery-mast-cutouts/requirements.txt
+++ b/notebooks/MAST/astroquery/astroquery-mast-cutouts/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib >= 3.4.3
+astropy >= 5.1.1
+astroquery >= 0.4.6


### PR DESCRIPTION
This is a tutorial notebook showing how to use the Cutout services in `astroquery.mast`. Namely: 
* `astroquery.mast.Tesscut`
* `astroquery.mast.Hapcut`

The notebook contains two main sections: 
* Example 1: Showing the `astroquery.mast.Tesscut` functionality (`get_sectors`, `get_cutouts`, `download_cutouts`)
* Example 2: Showing the `astroquery.mast.Hapcut` functionality (`get_cutouts`, `download_cutouts`). 

A reference is made to the Jupyter Notebook demonstrating the `astroquery.mast.Zcut` functionality, which currently exists here: https://github.com/spacetelescope/mast_notebooks/blob/main/notebooks/astroquery/beginner_zcut/beginner_zcut.ipynb