### PR TITLE
Refactor notebook "Launch menu" items

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,7 @@ launch_buttons:
   # colab_url: "https://colab.research.google.com"
   jupyterhub: true
   jupyterhub_url: "https://timeseries.science.stsci.edu"
+  notebook_interface: jupyterlab
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository

--- a/_config.yml
+++ b/_config.yml
@@ -36,8 +36,10 @@ repository:
   branch: main  # Which branch of the repository should be used when creating links (optional)
   
 launch_buttons:
-  binderhub_url: "https://mybinder.org"  # The URL for your BinderHub (e.g., https://mybinder.org)
-  colab_url: "https://colab.research.google.com"
+  # binderhub_url: "https://mybinder.org"  # The URL for your BinderHub (e.g., https://mybinder.org)
+  # colab_url: "https://colab.research.google.com"
+  jupyterhub: true
+  jupyterhub_url: "https://timeseries.science.stsci.edu"
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository


### PR DESCRIPTION
**Relevant Ticket**
- [SPB-1502](https://jira.stsci.edu/browse/SPB-1502)

**Summary of Changes**
- Changed which services are available to users to interact with and run notebooks in "launch" menu with an update to the _config.yml file.
- Current available services (binder and colab) will be replaced with TIKE, which is a jupyterhub  service hosted by Space Telescope (See [https://timeseries.science.stsci.edu/](https://timeseries.science.stsci.edu/))
- Notebooks will use jupyterlab interface