### PR TITLE
Fix bug preventing 'colab' and 'binder' launch menu buttons from opening Jupyter notebooks correctly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ bibtex_bibfiles:
 # Information about where the book exists on the web
 repository:
   url: https://github.com/spacetelescope/mast_notebooks  # Online location of your book
-  path_to_book: notebooks  #Optional path to your book, relative to the repository root
+  # path_to_book: notebooks  #Optional path to your book, relative to the repository root
   branch: main  # Which branch of the repository should be used when creating links (optional)
   
 launch_buttons:


### PR DESCRIPTION
- The 'path_to_book' param was contaminating the URL used to launch notebooks in binder and colab leading to "notebook not found" errors. 
- Commenting out this param remedies the issue. 