### PR TITLE
Replace 'colab' and 'binder' with 'Jupyterhub' in 'Launch' menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,15 +32,15 @@ bibtex_bibfiles:
 # Information about where the book exists on the web
 repository:
   url: https://github.com/spacetelescope/mast_notebooks  # Online location of your book
-  path_to_book: notebooks  #Optional path to your book, relative to the repository root
+  # path_to_book: notebooks  #Optional path to your book, relative to the repository root
   branch: main  # Which branch of the repository should be used when creating links (optional)
   
 launch_buttons:
-  binderhub_url: "https://mybinder.org"  # The URL for your BinderHub (e.g., https://mybinder.org)
-  colab_url: "https://colab.research.google.com"
-  # jupyterhub: true
-  # jupyterhub_url: "https://timeseries.science.stsci.edu"
-  # notebook_interface: jupyterlab
+  # binderhub_url: "https://mybinder.org"  # The URL for your BinderHub (e.g., https://mybinder.org)
+  # colab_url: "https://colab.research.google.com"
+  jupyterhub: true
+  jupyterhub_url: "https://timeseries.science.stsci.edu"
+  notebook_interface: jupyterlab
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository


### PR DESCRIPTION
**Relevant Tickets and PRs**
- Ticket SPB-1502
- PR #51 
- PR #52 
- PR #53 

**High-Level Summary**
- The issue with mast_notebooks/ content not launching in TIKE was found to be a server-side issue that could be solved by removing an existing clone of the mast_notebooks in the virtual environment and that the changes in PR #52 could be reverted. 

**Summary of Changes**
- Returned the *launch buttons* section of the _config.yml file back to the state post-PR #51 merge. 
  - Commented out 'binderhub_url' and  'colab_url' params in _config.yml. 
  - Uncommented 'jupyterhub', 'jupyterhub_url' and 'notebook_interface' params in _config.yml. 
- Commented out the 'path_to_book' param in _config.yml. 
  -  It was contaminating the URL used to launch notebooks in binder and colab leading to "notebook not found" errors.