### PR TITLE
Create weekly_broken_link_finder.yml

### DIFF
--- a/.github/workflows/weekly_broken_link_finder.yml
+++ b/.github/workflows/weekly_broken_link_finder.yml
@@ -1,0 +1,10 @@
+name: Weekly broken link check
+on:
+  schedule:
+    - cron: '0 4 * * 0' # 0400 UTC every Sunday
+
+jobs:
+  Scheduled:
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/broken_link_checker.yml@main
+   with:
+     website_url: "https://spacetelescope.github.io/mast_notebooks/intro.html"


### PR DESCRIPTION
This PR adds a caller workflow that will run notebook-ci-actions workflow [broken_link_checker.yml ](https://github.com/spacetelescope/notebook-ci-actions/blob/main/.github/workflows/broken_link_checker.yml) to identify broken links in https://spacetelescope.github.io/mast_notebooks/ weekly every Sunday at 0400 UTC (2000 ET).