### PR TITLE
Change np.NaN to np.nan in FIMS-SPEAR notebook.

### DIFF
--- a/notebooks/MCCM/FIMS-SPEAR/hyperspectral_healpix_maps/hyperspectral_healpix_maps.ipynb
+++ b/notebooks/MCCM/FIMS-SPEAR/hyperspectral_healpix_maps/hyperspectral_healpix_maps.ipynb
@@ -239,7 +239,7 @@
     "\n",
     "# Load the data with astropy.\n",
     "l_n064 = Table.read('mccm_fims-spear_fims-ap100-n064_sky-starless_long_v1.0_hp-map-hsi.fits.gz', \n",
-    "                    hdu=1).filled(np.NaN) # The \".filled(np.NaN)\" is important; see \"a note about NaNs\" below.\n",
+    "                    hdu=1).filled(np.nan) # The \".filled(np.nan)\" is important; see \"a note about NaNs\" below.\n",
     "\n",
     "# Integrate over wavelength and plot the data.\n",
     "hp.mollview(np.sum(l_n064['INTEN_BSUB'], axis=1), coord='G', max=5e6, unit='photon cm-2 s-1 sr-1', title='') # Galactic coordinates"
@@ -340,13 +340,13 @@
     "hdul.close()\n",
     "\n",
     "l_n064 = Table.read('mccm_fims-spear_fims-ap100-n064_sky-starless_long_v1.0_hp-map-hsi.fits.gz', \n",
-    "                    hdu=1).filled(np.NaN)\n",
+    "                    hdu=1).filled(np.nan)\n",
     "\n",
     "s_n064 = Table.read('mccm_fims-spear_fims-ap100-n064_sky-starless_short_v1.0_hp-map-hsi.fits.gz', \n",
-    "                    hdu=1).filled(np.NaN)\n",
+    "                    hdu=1).filled(np.nan)\n",
     "\n",
     "l_n512 = Table.read(file_n512, \n",
-    "                    hdu=1).filled(np.NaN) # this one may take a minute"
+    "                    hdu=1).filled(np.nan) # this one may take a minute"
    ]
   },
   {
@@ -354,7 +354,7 @@
    "id": "c6020dd5",
    "metadata": {},
    "source": [
-    "(A note about NaNs: You might be wondering why we needed `.filled(np.NaN)`. There are regions of the sky without coverage by FIMS-SPEAR, which are represented as NaN values in the FITS binary table. By default, `astropy.Table` masks these pixels with the `numpy` fill value for masking floats, 1e20. But the `healpy` fill value for masking bad data is -1.6375e+30. Plus, we're sometimes going to need to sum arrays over the wavelength axis, and we don't want to sum up either of these fill values. So, here we're bypassing the problem entirely by using NaNs instead of masking fill values.)"
+    "(A note about NaNs: You might be wondering why we needed `.filled(np.nan)`. There are regions of the sky without coverage by FIMS-SPEAR, which are represented as NaN values in the FITS binary table. By default, `astropy.Table` masks these pixels with the `numpy` fill value for masking floats, 1e20. But the `healpy` fill value for masking bad data is -1.6375e+30. Plus, we're sometimes going to need to sum arrays over the wavelength axis, and we don't want to sum up either of these fill values. So, here we're bypassing the problem entirely by using NaNs instead of masking fill values.)"
    ]
   },
   {
@@ -739,9 +739,9 @@
    "source": [
     "# Load the data\n",
     "l_n064_spear = Table.read('mccm_fims-spear_spear-ap100-n064_sky-starless_long_v1.0_hp-map-hsi.fits.gz', \n",
-    "                          hdu=1).filled(np.NaN)\n",
+    "                          hdu=1).filled(np.nan)\n",
     "s_n064_spear = Table.read('mccm_fims-spear_spear-ap100-n064_sky-starless_short_v1.0_hp-map-hsi.fits.gz', \n",
-    "                          hdu=1).filled(np.NaN)"
+    "                          hdu=1).filled(np.nan)"
    ]
   },
   {


### PR DESCRIPTION
Trivial fix for a notebook that is [failing execution](https://github.com/spacetelescope/mast_notebooks/actions/runs/10231843224/job/28308252456#step:6:111). Just changes every instance of `np.NaN` to `np.nan`.