### PR TITLE
Downloading Mission-Specific Data with Astroquery

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -93,6 +93,7 @@ parts:
         - file:  notebooks/multi_mission/large_downloads/large_downloads.ipynb
         - file:  notebooks/multi_mission/historic_quasar_observations/historic_quasar_observations.ipynb
         - file:  notebooks/multi_mission/wildcard_searches/wildcard_searches.ipynb
+        - file:  notebooks/multi_mission/missions_mast_search/missions_mast_search.ipynb
     - file:  notebooks/multi_mission/display_footprints/display_footprints.ipynb
 
   - caption: PanSTARRS

--- a/notebooks/multi_mission/astroquery.md
+++ b/notebooks/multi_mission/astroquery.md
@@ -16,3 +16,5 @@ The [`astroquery.mast` readthedocs](https://astroquery.readthedocs.io/en/latest/
 | Beginner ZCut   | The `zcut` feature enables you to request cutouts from [various deep field surveys](https://mast.stsci.edu/zcut/).                                           |
 | Large Downloads | When downloading large datasets, you may encounter timeout errors. This Notebook demonstrates robust queries that are less likely to encounter these issues. |
 | Historic Quasar Observations | Much of the data in MAST is archival; from no longer operational missions. Learn to check for archival coverage of your target and analyze the results. |
+| Searching for Mission-Specific Data with Astroquery | Learn the basic workflow for searching mission datasets, retrieving data products, and 
+downloading data products with the `MastMissions` class, a wrapper around the [MAST Search API.](https://mast.stsci.edu/search/docs/) |

--- a/notebooks/multi_mission/missions_mast_search/Searching_Mission-Specific-Data_with_Astroquery.ipynb
+++ b/notebooks/multi_mission/missions_mast_search/Searching_Mission-Specific-Data_with_Astroquery.ipynb
@@ -1,0 +1,994 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"top\"></a>\n",
+    "# Searching for Mission-Specific Data with Astroquery\n",
+    "***\n",
+    "## Learning Goals\n",
+    "\n",
+    "By the end of this tutorial, you will:\n",
+    "\n",
+    "- Understand how to use the `astroquery.mast` module to access mission dataset metadata from MAST.\n",
+    "- Run metadata queries based on coordinates, an object name, or non-positional criteria.\n",
+    "- Filter and download data products associated with datasets of interest.\n",
+    "- Search for datasets from multiple missions and among [High Level Science Products (HLSPs)](https://outerspace.stsci.edu/display/MASTDOCS/About+HLSPs)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Table of Contents\n",
+    "* [Introduction](#introduction)\n",
+    "\n",
+    "* [Imports](#imports)\n",
+    "\n",
+    "* [Querying for Datasets from Missions-MAST](#querying-for-datasets-from-missions-mast)\n",
+    "\n",
+    "  * [Search Parameters](#search-parameters)\n",
+    "\n",
+    "  * [Query by Object Name](#query-by-object-name)\n",
+    "\n",
+    "  * [Query by Region](#query-by-Region)\n",
+    "\n",
+    "  * [Query by Criteria](#query-by-criteria)\n",
+    "\n",
+    "* [Getting Data Products](#getting-data-products)\n",
+    "\n",
+    "   * [Performing a Product Query](#performing-a-product-query)\n",
+    "\n",
+    "   * [Filtering Data Products](#filtering-data-products)\n",
+    "\n",
+    "* [Downloading Products](#downloading-products)\n",
+    "\n",
+    "   * [Exclusive Data Access](#exclusive-data-access)\n",
+    "\n",
+    "* [Switching Missions](#switching-missions)\n",
+    "\n",
+    "* [Exercises](#exercises)\n",
+    "\n",
+    "* [Exercise Solutions](#exercise-solutions)\n",
+    "\n",
+    "* [Additional Resources](#additional-resources)\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Welcome! This tutorial explores the capabilities of the `astroquery.mast.MastMissions` class, a versatile tool for accessing and working with datasets hosted by the [Mikulski Archive for Space Telescopes (MAST)](https://archive.stsci.edu/). `MastMissions` is a Python wrapper for the [MAST Search API](https://mast.stsci.edu/search/docs/), which allows you to search for mission-specific dataset metadata and data products. This data is also findable through the [MAST Search UI](https://mast.stsci.edu/search/ui/#/).\n",
+    "\n",
+    "The following missions/products are available for search at time of writing:\n",
+    "\n",
+    "- [Hubble Space Telescope](https://www.stsci.edu/hst) (`hst`)\n",
+    "- [James Webb Space Telescope](https://www.stsci.edu/jwst) (`jwst`)\n",
+    "- [High Level Science Products](https://outerspace.stsci.edu/display/MASTDOCS/About+HLSPs)\n",
+    "  - [COS Legacy Archive Spectroscopic SurveY](https://archive.stsci.edu/hlsp/classy) (`classy`)\n",
+    "  - [Hubble UV Legacy Library of Young Stars as Essential Standards](https://archive.stsci.edu/hlsp/ullyses) (`ullyses`)\n",
+    "\n",
+    "In this notebook, we will walk through the basic workflow for searching datasets, retrieving data products, and downloading data products. This workflow will look very similar to the one used with the [`astroquery.mast.Observations`](https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html) class, detailed in our [\"Searching MAST using astroquery.mast\" notebook](https://github.com/spacetelescope/mast_notebooks/blob/main/notebooks/multi_mission/beginner_search/beginner_search.ipynb). There are a few key differences to note, and you should use the class that is best suited for your unique goals:\n",
+    "\n",
+    "* *API*: `MastMissions` uses the [Mast Search API](https://mast.stsci.edu/search/docs/) while `Observations` uses the [MAST Portal API](https://mast.stsci.edu/api/v0/).\n",
+    "* *Collection*: `MastMissions` can only perform queries on a single collection, or \"mission\", at a time. `Observations` uses the [Common Archive Observation Model (CAOM)](https://mast.stsci.edu/vo-tap/api/v0.1/caom/) and can run queries across every available observational collection at the same time.\n",
+    "* *Filter Keywords*: `MastMissions` has an extensive selection of mission-specific keywords to use while writing queries. `Observations` is limited to the [fields described by the CAOM](https://mast.stsci.edu/api/v0/_c_a_o_mfields.html) and has no criteria with mission-specific meaning.\n",
+    "\n",
+    "In summary, `MastMissions` is well-suited for fast, mission-specific queries that might require a more extensive selection of filter keywords. `Observations` is better for more broad, multi-mission searches."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Imports\n",
+    "This notebook uses the following packages:\n",
+    "\n",
+    "- *astropy* to handle astronomical units and coordinate systems\n",
+    "- *astroquery.mast* to query the MAST Archive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astroquery.mast import MastMissions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying for Datasets from Missions-MAST\n",
+    "\n",
+    "In order to make queries on Missions-MAST metadata, we will have to perform some setup. We will instantiate an object of the `astroquery.mast.MastMissions` class and assign its `mission` attribute. The object can be used to search mission dataset metadata by object name, sky position, or other criteria.\n",
+    "\n",
+    "The default value for `mission` is `hst`, meaning that queries will be run on Hubble dataset metadata. The searchable metadata for Hubble encompasses all information that was previously accessible through the original HST web search form. The metadata for Hubble and all other available missions is also available through the [MAST Search UI](https://mast.stsci.edu/search/ui/#/).\n",
+    "\n",
+    "Later in the tutorial, we will learn how to change the `mission` attribute to make queries on other missions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create MastMissions object to search for Hubble datasets\n",
+    "missions = MastMissions(mission='hst')\n",
+    "missions.mission"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Search Parameters\n",
+    "\n",
+    "When writing queries, keyword arguments can be used to specify output characteristics and filter on values like instrument, exposure type, and proposal ID. The available column names for a mission are returned by the `get_column_list` function. Below, we will print out the name, data type, and description for the first 10 columns in HST metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get available columns for HST mission\n",
+    "columns = missions.get_column_list()\n",
+    "columns[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can refine our results even further with optional keyword arguments. The following parameters are available:\n",
+    "\n",
+    "- `radius`: For positional searches only. Only return results within a certain distance from an object or set of coordinates. Default is 3 arcminutes. \n",
+    "\n",
+    "- `limit`: The maximum number of results to return. Default is 5000.\n",
+    "- `offset`: Skip the first ***n*** results. Useful for paging through results.\n",
+    "- `sort_by`: A list of field names to sort by.\n",
+    "- `sort_desc`: A list of booleans (one for each field specified in `sort_by`), describing if each field should be sorted in descending order (`True`) or ascending order (`False`)\n",
+    "- `select_cols`: A list of columns to be returned in the response.\n",
+    "\n",
+    "As we walk through different types of queries, we will see these parameters in action!\n",
+    "\n",
+    "### Query by Object Name\n",
+    "\n",
+    "We've reached our first query! We can use object names to perform metadata queries using the `query_object` function.\n",
+    "\n",
+    "To start, let's query for the [Messier 1](https://science.nasa.gov/mission/hubble/science/explore-the-night-sky/hubble-messier-catalog/messier-1/) object, a supernova remnant in the Taurus constellation. You may know it better as the Crab Nebula!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query for Messier 1 ('M1')\n",
+    "results = missions.query_object('M1')\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There were 681 total results, meaning that 681 HST datasets were targeting the Crab Nebula. Now, let's try refining our search a bit more.\n",
+    "\n",
+    "- Each dataset is associated with a celestial coordinate, given by `sci_ra` (right ascension) and `sci_dec` (declination). By default, the query returns all datasets that fall within 3 arcminutes from the object's coordinates. Let's set the `radius` parameter to be 1 arcminute instead.\n",
+    "- Say that we're not interested in the first 4 results. We can assign `offset` to skip a certain number of rows.\n",
+    "- By default, a subset of recommended columns are returned for each query. However, we can specify exactly which columns to return using the `select_cols` keyword argument. Certain columns are included automatically, depending on the mission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Refined query for Messier 1 ('M1')\n",
+    "results = missions.query_object('M1',\n",
+    "                                radius=1,  # Search within a 1 arcminute radius\n",
+    "                                offset=4,  # Skip the first 4 results\n",
+    "                                select_cols=['sci_start_time', 'sci_pi_last_name'])  # Select certain columns\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query by Region\n",
+    "\n",
+    "The `missions` object also allows us to query by a region in the sky. By passing in a set of coordinates to the `query_region` function, we can return datasets that fall within a certain `radius` value of that point. This type of search is also known as a cone search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create coordinate object\n",
+    "coords = SkyCoord(210.80227, 54.34895, unit=('deg'))\n",
+    "\n",
+    "# Query for results within 10 arcseconds of coordinates\n",
+    "results = missions.query_region(coords, \n",
+    "                                radius=10 * u.arcsec)\n",
+    "\n",
+    "# Display results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "19 HST datasets fall within our cone search. In other words, their target coordinates are within 10 arcseconds of the coordinates that we defined."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query by Criteria\n",
+    "\n",
+    "In some cases, we may want to run queries with non-positional parameters. To accomplish this, we use the `query_criteria` function.\n",
+    "\n",
+    "For any of our query functions, we can filter our results by the value of columns in the dataset.\n",
+    "\n",
+    "Let's say that we want observations from [HST's Wide Field Camera 3 (WFC3)](https://www.stsci.edu/hst/instrumentation/wfc3) instument that use the F555W filter. We are only interested in datasets connected to [proposal number 15879](https://www.stsci.edu/hst-program-info/program/?program=15879)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query with column criteria\n",
+    "results = missions.query_criteria(sci_instrume='WFC3',  # From Wide Field Camera 3\n",
+    "                                  sci_spec_1234='F555W',  # Uses F555W filter\n",
+    "                                  sci_pep_id=15879,  # Proposal number 15879\n",
+    "                                  select_cols=['sci_instrume', 'sci_spec_1234', 'sci_pep_id', 'sci_pi_last_name'])\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To exclude and filter out a certain value from the results, we can prepend the value with `!`.\n",
+    "\n",
+    "Let's run the same query as above, but this time, we will filter out datasets that use the F555W filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filtered query, excluding datasets using F555W filter\n",
+    "results = missions.query_criteria(sci_instrume='WFC3', \n",
+    "                                  sci_spec_1234='!F555W',  # Excludes datasets that use F555W filter\n",
+    "                                  sci_pep_id=15879,\n",
+    "                                  select_cols=['sci_instrume', 'sci_spec_1234', 'sci_pep_id', 'sci_pi_last_name'])\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also use wildcards on string criteria for more advanced filtering. Wildcards are special characters used in search patterns to represent one or more unknown characters, allowing for flexible matching of strings. The wildcard character is `*`: it replaces any number of characters preceding, following, or in between the existing characters, depending on its placement.\n",
+    "\n",
+    "Let's use the same query from above, but we will add the condition that the target name must contain the string \"GEM\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filtered query with wildcard\n",
+    "results = missions.query_criteria(sci_instrume='WFC3', \n",
+    "                                  sci_spec_1234='!F555W',\n",
+    "                                  sci_pep_id=15879,\n",
+    "                                  sci_targname='*GEM*',  # Must contain the string 'GEM'\n",
+    "                                  select_cols=['sci_instrume', 'sci_spec_1234', 'sci_pep_id', 'sci_pi_last_name'])\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To filter by multiple values for a single column, we use a string of the values delimited by commas.\n",
+    "\n",
+    "To illustrate this, we will use a slightly different query. We query for WFC3 datasets from proposal 15879 that use either the F153M filter or the F160W filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filtered query with multiple values\n",
+    "results = missions.query_criteria(sci_instrume='WFC3', \n",
+    "                                  sci_spec_1234='F153M, F160W',  # Uses either F153M filter OR F160W filter\n",
+    "                                  sci_pep_id=15879,\n",
+    "                                  select_cols=['sci_instrume', 'sci_spec_1234', 'sci_pep_id', 'sci_pi_last_name'])\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For columns with numeric or date values, we can filter using comparison values:\n",
+    "\n",
+    "- `<`: Return values less than or before the given number/date\n",
+    "- `>`: Return values greater than or after the given number/date\n",
+    "- `<=`: Return values less than or equal to the given number/date\n",
+    "- `>=`: Return values greater than or equal to the given number/date\n",
+    "\n",
+    "As an example, let's write a query to return all datasets with an observation date before May 1, 1990. These were some of Hubble's first observations! We'll use the optional `sort_by` and `sort_desc` keywords to sort our results in reverse chronological order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query using comparison operator\n",
+    "results = missions.query_criteria(sci_start_time='<1990-05-01',  # Must be observed before May 1, 1990\n",
+    "                                  select_cols=['sci_start_time', 'sci_pep_id'],\n",
+    "                                  sort_by=['sci_start_time'],  # Sort by observation start time\n",
+    "                                  sort_desc=[True])  # Sort in descending order\n",
+    "\n",
+    "# Display the first 10 results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For numeric or date data types, we can also filter with ranges. This requires the following syntax: `'#..#'`.\n",
+    "\n",
+    "Let's write a query that uses range syntax to return datasets that have an exposure time between 5000 and 5005 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query using range operator\n",
+    "results = missions.query_criteria(sci_actual_duration='5000..5005',  # Exposure duration is between 5000 and 5005 seconds\n",
+    "                                  select_cols=['sci_pep_id', 'sci_actual_duration'])\n",
+    "\n",
+    "# Display results\n",
+    "print(f'Total number of results: {len(results)}')\n",
+    "results[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Wow, there's a lot of tips and tricks for writing queries! Here's a quick summary:\n",
+    "\n",
+    "* To exclude and filter out a certain value from the results, prepend the value with ``!``.\n",
+    "\n",
+    "* Wildcards are special characters used in search patterns to represent one or more unknown characters, \n",
+    "  allowing for flexible matching of strings. The wildcard character is ``*`` and it replaces any number\n",
+    "  of characters preceding, following, or in between existing characters, depending on its placement.\n",
+    "\n",
+    "* To filter by multiple values for a single column, use a string of values delimited by commas.\n",
+    "\n",
+    "* For columns with numeric or date data types, filter using comparison values (``<``, ``>``, ``<=``, ``>=``).\n",
+    "\n",
+    "* For columns with numeric or date data types, select a range with the syntax ``'#..#'``."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Data Products\n",
+    "\n",
+    "### Performing a Product Query\n",
+    "\n",
+    "Each observation returned from a MAST query can have one or more associated data products. For example, a JWST observation might return an [uncalibrated file](https://outerspace.stsci.edu/display/MASTDOCS/Supplemental+Products), [a guide-star file](https://jwst-docs.stsci.edu/jwst-observatory-characteristics/jwst-guide-stars), and the actual science data.\n",
+    "\n",
+    "For reproducibility, we'll run another criteria query for datasets that use Hubble's [Advanced Camera for Surveys (ACS)](https://www.stsci.edu/hst/instrumentation/acs) instrument. We are interested in datasets connected to [proposal number 12451](https://www.stsci.edu/hst-program-info/program/?program=12451) that are associated with at least one High Level Science Product."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query using range operator\n",
+    "datasets = missions.query_criteria(sci_pep_id=12451,  # Proposal number 12451\n",
+    "                                   sci_instrume='ACS',  # Use ACS instrument\n",
+    "                                   sci_hlsp='>1')  # Associated with at least one HLSP\n",
+    "\n",
+    "# Display results\n",
+    "print(f'Total number of results: {len(datasets)}')\n",
+    "datasets[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `get_product_list` function accepts a table of datasets or a list of dataset IDs and returns a table containing the associated data products. Let's fetch the data products for the first three datasets in the table above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of data products\n",
+    "products = missions.get_product_list(datasets[:3])\n",
+    "\n",
+    "# Display results\n",
+    "print(f'Total number of products: {len(products)}')\n",
+    "products[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some products can be associated with multiple datasets, and this table may contain duplicates. To return a list of products with only unique filenames, use the `get_unique_product_list` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get products with unique filenames\n",
+    "unique_products = missions.get_unique_product_list(datasets[:3])\n",
+    "\n",
+    "# Display results\n",
+    "unique_products[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filtering Data Products\n",
+    "\n",
+    "These datasets returned quite a few products! We are not interested in all of them, and luckily, we have a handy function to filter them for us. `filter_products` allows you to filter based on file extension (`extension`) and any other of the product fields.\n",
+    "\n",
+    "A quick note on filtering: the **AND** operation is performed for a list of filters, and the **OR** operation is performed within a filter set. For example, the filter below will return FITS products that are \"science\" type **and** have a `file_suffix` of [\"ASN\" (association files)](https://hst-docs.stsci.edu/acsdhb/chapter-2-acs-data-structure/2-1-types-of-acs-files#id-2.1TypesofACSFiles-2.1.22.1.2AssociationTables) **or** [\"JIF\" (jitter information files)](https://www.stsci.edu/hst/instrumentation/focus-and-pointing/pointing/jitter-file-format-definition)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filter products \n",
+    "filtered = missions.filter_products(products,\n",
+    "                                    extension='fits',  # FITS file extension\n",
+    "                                    type='science',\n",
+    "                                    file_suffix=['ASN', 'JIF'])  # Association files OR jitter information files\n",
+    "\n",
+    "# Display results\n",
+    "filtered"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Downloading Products\n",
+    "\n",
+    "The `download_products` function accepts a table of products like the one above and will download the products to your local machine. By default, products will be downloaded into the current working directory, in a subdirectory called `mastDownload`. The full local filepaths will have the form `mastDownload/<mission>/<Dataset ID>/file.` You can change the download directory using the `download_dir` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download products using filtered product Table\n",
+    "manifest = missions.download_products(filtered[:2])\n",
+    "\n",
+    "# Display results\n",
+    "manifest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a more streamlined workflow, the function also accepts dataset IDs and product filters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download products using dataset IDs and product filters\n",
+    "manifest = missions.download_products(['JBTAA0010', 'JBTAA0020'],\n",
+    "                                      extension='fits',\n",
+    "                                      type='science',\n",
+    "                                      file_suffix=['ASN', 'JIF'])\n",
+    "\n",
+    "# Display results\n",
+    "manifest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To download a single data product file, use the `download_file` function with a MAST URI as input. \n",
+    "The default is to download the file to the current working directory, but you can specify the download \n",
+    "directory or filepath with the `local_path` keyword argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download a single data product\n",
+    "result = missions.download_file('JBTAA0010/jbtaa0010_asn.fits')\n",
+    "\n",
+    "# Display result\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exclusive Data Access\n",
+    "\n",
+    "Some data may not be publicly available. To [download proprietary data](https://astroquery.readthedocs.io/en/latest/mast/mast.html#accessing-proprietary-data), you will need a [MyST Account](https://proper.stsci.edu/proper/authentication/auth) with proper permissions. You will also need to provide an [API token](https://auth.mast.stsci.edu/info). \n",
+    "\n",
+    "You can use the `login` function to authenticate yourself. After executing the following cell, you should be prompted to enter your token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#missions.login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also provide a token to a `MastMissions` object upon initialization using the `mast_token` parameter. However, remember to be cautious with your API token. You should not share the token or check it into source control. For the best security, we recommend using the `login` method to authenticate yourself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Switching Missions\n",
+    "\n",
+    "As mentioned previously, each `MastMissions` object can only make queries and download products from a single collection at a time. This collection can be modified with the `mission` class attribute, which is case-insensitive. This allows users to query multiple collections with the same object. \n",
+    "\n",
+    "To demonstrate, we'll create a new `MastMissions` object and initialize the `mission` to be `'JWST'`. This will perform queries on dataset metadata from the James Webb Space Telescope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_mission = MastMissions(mission='JWST')\n",
+    "multi_mission.mission"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we'll query for JWST datasets around [NGC 346](https://science.nasa.gov/image-detail/young-stars-sculpt-gas-with-powerful-outflows/), a young star cluster in the [Small Magellanic Cloud](https://www.nasa.gov/image-article/taken-under-wing-of-small-magellanic-cloud/). We'll use a radius of 0.2 arcminutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query JWST for NGC 346\n",
+    "results = multi_mission.query_object('NGC 346',\n",
+    "                                     radius=0.2)  # Search within a 0.2 arcminute radius\n",
+    "\n",
+    "# Display results\n",
+    "print(f'Total number of datasets: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This query returned 168 JWST datasets. Now, let's try it with a different data collection. We'll reassign the `mission` attribute on the `multi_mission` object to be `'ullyses'` and run the same query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_mission.mission = 'ullyses'\n",
+    "multi_mission.mission"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query ULLYSES for NGC 346\n",
+    "results = multi_mission.query_object('NGC 346',\n",
+    "                                     radius=0.2)  # Search within a 0.5 arcminute radius\n",
+    "\n",
+    "# Display results\n",
+    "print(f'Total number of datasets: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that this query only returned 2 datasets. The result tables also look very different in terms of data and column keywords. This is because each query is being performed on a different data collection!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "**Exercise 1**: It's time to apply all that you've learned and try your hand at writing a `MastMissions` query! Write a non-positional query based on the following:\n",
+    "\n",
+    "- Image observations\n",
+    "- Instrument should NOT include the [Cosmic Origins Spectrograph (COS)](https://www.stsci.edu/hst/instrumentation/cos)\n",
+    "- Filter used is F150W, F105W, or F110W\n",
+    "- Declination is greater than 0 degrees\n",
+    "- Exposure time is between 1000 and 2000 seconds\n",
+    "- Skip the first 5 entries\n",
+    "- Sort by exposure time in descending order\n",
+    "- Limit the results to 3 datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A non-positional query with column criteria\n",
+    "# results = missions.query_criteria(...)  # Write your query here!\n",
+    "\n",
+    "# Display results\n",
+    "# results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Exercise 2**: Using your results from Exercise 1, download the association table data products for the 3 datasets (HINT: `file_suffix = 'ASN'`). You can fetch, filter, and download the products as three separate steps, or use the streamlined workflow built in to `download_products`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fetch products from 3 datasets\n",
+    "# products = missions.get_product_list(...)\n",
+    "\n",
+    "# Filter products\n",
+    "# filtered = missions.filter_products(...)\n",
+    "\n",
+    "# Download products\n",
+    "# missions.download_products(...)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Exercise 3**: Use a new `MastMissions` object and the `mission` attribute to search for datasets around the coordinate \"22h57m39s -29d37m20s\" from both HST and JWST. Use a radius of 0.1 arcminutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create new MastMissions object\n",
+    "#m = MastMissions()\n",
+    "\n",
+    "# Create sky coordinate object\n",
+    "#coord = SkyCoord(...)\n",
+    "\n",
+    "# Query HST metadata for region\n",
+    "#results = m.query_region(...)\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "#print(f'Total number of datasets: {len(results)}')\n",
+    "#results[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Switch mission to JWST\n",
+    "# ...\n",
+    "\n",
+    "# Query JWST metadata for region\n",
+    "#results = m.query_region(...)\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "#print(f'Total number of datasets: {len(results)}')\n",
+    "#results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise Solutions\n",
+    "\n",
+    "**Exercise 1:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A non-positional query with column criteria\n",
+    "results = missions.query_criteria(sci_obs_type='IMAGE',\n",
+    "                                  sci_instrume='!COS',\n",
+    "                                  sci_spec_1234='F150W, F105W, F110W',\n",
+    "                                  sci_dec='>0',\n",
+    "                                  sci_actual_duration='1000..2000',\n",
+    "                                  sci_targname='*GAL*',\n",
+    "                                  offset=5,\n",
+    "                                  sort_by=['sci_actual_duration'],\n",
+    "                                  sort_desc=[True],\n",
+    "                                  limit=3)\n",
+    "\n",
+    "# Display results\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Exercise 2:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As 3 separate steps\n",
+    "# Fetch products from first 3 datasets\n",
+    "products = missions.get_product_list(results)\n",
+    "\n",
+    "# Filter products\n",
+    "filtered = missions.filter_products(products,\n",
+    "                                    file_suffix='ASN')\n",
+    "\n",
+    "# Download products\n",
+    "missions.download_products(filtered)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Streamlined\n",
+    "missions.download_products(results['sci_data_set_name'].tolist(),\n",
+    "                           file_suffix='ASN')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Exercise 3:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create new MastMissions object\n",
+    "m = MastMissions()\n",
+    "\n",
+    "# Create sky coordinate object\n",
+    "coord = SkyCoord('22h57m39s -29d37m20s')\n",
+    "\n",
+    "# Query HST metadata for region\n",
+    "results = m.query_region(coord,\n",
+    "                         radius=0.1)\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "print(f'Total number of datasets: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Switch mission to JWST\n",
+    "m.mission = 'JWST'\n",
+    "\n",
+    "# Query JWST metadata for region\n",
+    "results = m.query_region(coord,\n",
+    "                         radius=0.1)\n",
+    "\n",
+    "# Display the first 5 results\n",
+    "print(f'Total number of datasets: {len(results)}')\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Resources\n",
+    "\n",
+    "- [MAST Search Form UI](https://mast.stsci.edu/search/ui/#/)\n",
+    "- [MAST Search API](https://mast.stsci.edu/search/docs/)\n",
+    "- [`astroquery.mast` Documentation for Mission Searches](https://astroquery.readthedocs.io/en/latest/mast/mast_missions.html#mission-specific-search-queries)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Citations\n",
+    "\n",
+    "If you use `astroquery` for published research, please cite the\n",
+    "authors. Follow these links for more information about citing `astroquery`:\n",
+    "\n",
+    "* [Citing Astroquery](https://github.com/astropy/astroquery/blob/main/astroquery/CITATION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## About this Notebook\n",
+    "\n",
+    "**Author(s):** Sam Bianco <br>\n",
+    "**Keyword(s):** Tutorial, Astroquery, MastMissions <br>\n",
+    "**First published:** December 2024 <br>\n",
+    "**Last updated:** December 2024 <br>\n",
+    "\n",
+    "***\n",
+    "[Top of Page](#top)\n",
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/style-guides/master/guides/images/stsci-logo.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/multi_mission/missions_mast_search/missions_mast_search.ipynb
+++ b/notebooks/multi_mission/missions_mast_search/missions_mast_search.ipynb
@@ -62,7 +62,7 @@
     "\n",
     "Welcome! This tutorial explores the capabilities of the `astroquery.mast.MastMissions` class, a versatile tool for accessing and working with datasets hosted by the [Mikulski Archive for Space Telescopes (MAST)](https://archive.stsci.edu/). `MastMissions` is a Python wrapper for the [MAST Search API](https://mast.stsci.edu/search/docs/), which allows you to search for mission-specific dataset metadata and data products. This data is also findable through the [MAST Search UI](https://mast.stsci.edu/search/ui/#/).\n",
     "\n",
-    "The following missions/products are available for search at time of writing:\n",
+    "The following missions/products are available for search as of January 2025:\n",
     "\n",
     "- [Hubble Space Telescope](https://www.stsci.edu/hst) (`hst`)\n",
     "- [James Webb Space Telescope](https://www.stsci.edu/jwst) (`jwst`)\n",
@@ -70,7 +70,7 @@
     "  - [COS Legacy Archive Spectroscopic SurveY](https://archive.stsci.edu/hlsp/classy) (`classy`)\n",
     "  - [Hubble UV Legacy Library of Young Stars as Essential Standards](https://archive.stsci.edu/hlsp/ullyses) (`ullyses`)\n",
     "\n",
-    "In this notebook, we will walk through the basic workflow for searching datasets, retrieving data products, and downloading data products. This workflow will look very similar to the one used with the [`astroquery.mast.Observations`](https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html) class, detailed in our [\"Searching MAST using astroquery.mast\" notebook](https://github.com/spacetelescope/mast_notebooks/blob/main/notebooks/multi_mission/beginner_search/beginner_search.ipynb). There are a few key differences to note, and you should use the class that is best suited for your unique goals:\n",
+    "In this notebook, we will walk through the basic workflow for searching datasets, retrieving data products, and downloading data products. This workflow will look very similar to the one used with the [`astroquery.mast.Observations`](https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html) class, detailed in our [\"Searching MAST using astroquery.mast\" notebook](https://spacetelescope.github.io/mast_notebooks/notebooks/multi_mission/beginner_search/beginner_search.html). There are a few key differences to note, and you should use the class that is best suited for your unique goals:\n",
     "\n",
     "* *API*: `MastMissions` uses the [Mast Search API](https://mast.stsci.edu/search/docs/) while `Observations` uses the [MAST Portal API](https://mast.stsci.edu/api/v0/).\n",
     "* *Collection*: `MastMissions` can only perform queries on a single collection, or \"mission\", at a time. `Observations` uses the [Common Archive Observation Model (CAOM)](https://mast.stsci.edu/vo-tap/api/v0.1/caom/) and can run queries across every available observational collection at the same time.\n",
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 1,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -122,7 +122,7 @@
    "source": [
     "## Querying for Datasets from Missions-MAST\n",
     "\n",
-    "In order to make queries on Missions-MAST metadata, we will have to perform some setup. We will instantiate an object of the `astroquery.mast.MastMissions` class and assign its `mission` attribute. The object can be used to search mission dataset metadata by object name, sky position, or other criteria.\n",
+    "In order to make queries on Missions-MAST metadata, we will have to perform some setup. We will initialize an object of the `astroquery.mast.MastMissions` class and assign its `mission` attribute. The object can be used to search mission dataset metadata by object name, sky position, or other criteria.\n",
     "\n",
     "The default value for `mission` is `hst`, meaning that queries will be run on Hubble dataset metadata. The searchable metadata for Hubble encompasses all information that was previously accessible through the original HST web search form. The metadata for Hubble and all other available missions is also available through the [MAST Search UI](https://mast.stsci.edu/search/ui/#/).\n",
     "\n",
@@ -146,7 +146,7 @@
    "source": [
     "### Search Parameters\n",
     "\n",
-    "When writing queries, keyword arguments can be used to specify output characteristics and filter on values like instrument, exposure type, and proposal ID. The available column names for a mission are returned by the `get_column_list` function. Below, we will print out the name, data type, and description for the first 10 columns in HST metadata."
+    "When writing queries, keyword arguments can be used to specify output characteristics and filter on fields like instrument, exposure type, and proposal ID. The available column names for a mission are returned by the `get_column_list` function. Below, we will print out the name, data type, and description for the first 10 columns in HST metadata."
    ]
   },
   {
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There were 681 total results, meaning that 681 HST datasets were targeting the Crab Nebula. Now, let's try refining our search a bit more.\n",
+    "There were over 600 total results, meaning that hundreds of HST datasets were targeting the Crab Nebula. Now, let's try refining our search a bit more.\n",
     "\n",
     "- Each dataset is associated with a celestial coordinate, given by `sci_ra` (right ascension) and `sci_dec` (declination). By default, the query returns all datasets that fall within 3 arcminutes from the object's coordinates. Let's set the `radius` parameter to be 1 arcminute instead.\n",
     "- Say that we're not interested in the first 4 results. We can assign `offset` to skip a certain number of rows.\n",
@@ -256,7 +256,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "19 HST datasets fall within our cone search. In other words, their target coordinates are within 10 arcseconds of the coordinates that we defined."
+    "The above datasets fall within our cone search. In other words, their target coordinates are within 10 arcseconds of the coordinates that we defined."
    ]
   },
   {
@@ -532,7 +532,7 @@
     "# Filter products \n",
     "filtered = missions.filter_products(products,\n",
     "                                    extension='fits',  # FITS file extension\n",
-    "                                    type='science',\n",
+    "                                    type='science',  # Science data\n",
     "                                    file_suffix=['ASN', 'JIF'])  # Association files OR jitter information files\n",
     "\n",
     "# Display results\n",
@@ -612,18 +612,18 @@
    "source": [
     "### Exclusive Data Access\n",
     "\n",
-    "Some data may not be publicly available. To [download proprietary data](https://astroquery.readthedocs.io/en/latest/mast/mast.html#accessing-proprietary-data), you will need a [MyST Account](https://proper.stsci.edu/proper/authentication/auth) with proper permissions. You will also need to provide an [API token](https://auth.mast.stsci.edu/info). \n",
+    "Some data may not be publicly available and will require [authentication and authorization](https://outerspace.stsci.edu/display/MASTDOCS/Using+MAST+APIs#UsingMASTAPIs-authAuth.MAST). To [download proprietary data with Astroquery](https://astroquery.readthedocs.io/en/latest/mast/mast.html#accessing-proprietary-data), you will need a [MyST Account](https://proper.stsci.edu/proper/authentication/auth) with proper permissions. You will also need to provide an [API token](https://auth.mast.stsci.edu/info). \n",
     "\n",
-    "You can use the `login` function to authenticate yourself. After executing the following cell, you should be prompted to enter your token."
+    "You can use the `login` function to authenticate yourself. After uncommenting and executing the following cell, you should be prompted to enter your token."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#missions.login()"
+    "# missions.login()"
    ]
   },
   {
@@ -680,7 +680,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This query returned 168 JWST datasets. Now, let's try it with a different data collection. We'll reassign the `mission` attribute on the `multi_mission` object to be `'ullyses'` and run the same query."
+    "This query returned over 160 JWST datasets. Now, let's try it with a different data collection. We'll reassign the `mission` attribute on the `multi_mission` object to be `'ullyses'` and run the same query."
    ]
   },
   {
@@ -701,7 +701,7 @@
    "source": [
     "# Query ULLYSES for NGC 346\n",
     "results = multi_mission.query_object('NGC 346',\n",
-    "                                     radius=0.2)  # Search within a 0.5 arcminute radius\n",
+    "                                     radius=0.2)  # Search within a 0.2 arcminute radius\n",
     "\n",
     "# Display results\n",
     "print(f'Total number of datasets: {len(results)}')\n",
@@ -712,7 +712,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that this query only returned 2 datasets. The result tables also look very different in terms of data and column keywords. This is because each query is being performed on a different data collection!"
+    "Notice that this query returned only a few datasets. The result tables also look very different in terms of data and column keywords. This is because each query is being performed on a different data collection!"
    ]
   },
   {
@@ -728,6 +728,7 @@
     "- Filter used is F150W, F105W, or F110W\n",
     "- Declination is greater than 0 degrees\n",
     "- Exposure time is between 1000 and 2000 seconds\n",
+    "- Target name contains the string \"GAL\"\n",
     "- Skip the first 5 entries\n",
     "- Sort by exposure time in descending order\n",
     "- Limit the results to 3 datasets"
@@ -735,7 +736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -755,7 +756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,7 +799,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -961,8 +962,8 @@
     "\n",
     "**Author(s):** Sam Bianco <br>\n",
     "**Keyword(s):** Tutorial, Astroquery, MastMissions <br>\n",
-    "**First published:** December 2024 <br>\n",
-    "**Last updated:** December 2024 <br>\n",
+    "**First published:** January 2025 <br>\n",
+    "**Last updated:** January 2025 <br>\n",
     "\n",
     "***\n",
     "[Top of Page](#top)\n",

--- a/notebooks/multi_mission/missions_mast_search/requirements.txt
+++ b/notebooks/multi_mission/missions_mast_search/requirements.txt
@@ -1,0 +1,2 @@
+astropy>=6.1.0
+astroquery

--- a/notebooks/multi_mission/missions_mast_search/requirements.txt
+++ b/notebooks/multi_mission/missions_mast_search/requirements.txt
@@ -1,2 +1,2 @@
 astropy >= 6.1.0
-astroquery @ git+https://github.com/astropy/astroquery@main
+astroquery >= 0.4.9.post1

--- a/notebooks/multi_mission/missions_mast_search/requirements.txt
+++ b/notebooks/multi_mission/missions_mast_search/requirements.txt
@@ -1,2 +1,2 @@
-astropy>=6.1.0
-astroquery
+astropy >= 6.1.0
+astroquery @ git+https://github.com/astropy/astroquery@main

--- a/notebooks/multi_mission/missions_mast_search/requirements.txt
+++ b/notebooks/multi_mission/missions_mast_search/requirements.txt
@@ -1,2 +1,2 @@
 astropy >= 6.1.0
-astroquery @ git+https://github.com/astropy/astroquery@main
+astroquery >= 0.4.9

--- a/notebooks/multi_mission/missions_mast_search/requirements.txt
+++ b/notebooks/multi_mission/missions_mast_search/requirements.txt
@@ -1,2 +1,2 @@
 astropy >= 6.1.0
-astroquery >= 0.4.9
+astroquery @ git+https://github.com/astropy/astroquery@main


### PR DESCRIPTION
A notebook detailing the workflow for searching datasets, retrieving data products, and downloading data products using `astroquery.mast.MastMissions`, a wrapper to the MAST Search API. These changes haven't been merged into Astroquery yet (why the tests are failing), so leaving as a draft for now.