### PR TITLE
Fix execution of JWST EDB_Retrieval Notebook

### DIFF
--- a/notebooks/JWST/Engineering_Database_Retreival/EDB_Retrieval.ipynb
+++ b/notebooks/JWST/Engineering_Database_Retreival/EDB_Retrieval.ipynb
@@ -428,7 +428,8 @@
     "    n.renderers.extend([vline, hline])\n",
     "    \n",
     "    # Add a circle plot of x vs y with the color map applied.\n",
-    "    n.circle(source=data, x='x_value', y='y_value', fill_alpha=0.6, fill_color=mapper, line_color=None)\n",
+    "    radius = (data['x_value'].max() - data['x_value'].min()) / 100  # Standardize the radius of points\n",
+    "    n.circle(source=data, x='x_value', y='y_value', fill_alpha=0.6, fill_color=mapper, line_color=None, radius=radius)\n",
     "    \n",
     "    # Translate legend values from MJD to time stamps.\n",
     "    indices = list(range(0, len(mjd), int(len(mjd)/n_ticks)))\n",
@@ -505,7 +506,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "myenv",
    "language": "python",
    "name": "python3"
   },
@@ -519,7 +520,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/JWST/Engineering_Database_Retreival/EDB_Retrieval.ipynb
+++ b/notebooks/JWST/Engineering_Database_Retreival/EDB_Retrieval.ipynb
@@ -93,7 +93,7 @@
     "            f\"Downloading File: mast:jwstedb/{fname}\\n\",\n",
     "            f\" To: {folder}/{fname}\",\n",
     "        )\n",
-    "        url = urlStr.format(prefix,fname)\n",
+    "        url = urlStr.format(prefix, fname)\n",
     "        try:\n",
     "            urllib.request.urlretrieve(url, filename=f\"{folder}/{fname}\")\n",
     "        except urllib.error.HTTPError:\n",
@@ -141,7 +141,7 @@
     "            'SA_ZADUCMDX': times,\n",
     "            'SA_ZADUCMDY': times\n",
     "           }\n",
-    "for m,v in mnemonics.items():\n",
+    "for m, v in mnemonics.items():\n",
     "    print(m, v)"
    ]
   },
@@ -166,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fnames = ['-'.join([m, v['t_start'], v['t_end']]) + '.csv' for m,v in mnemonics.items()]\n",
+    "fnames = ['-'.join([m, v['t_start'], v['t_end']]) + '.csv' for m, v in mnemonics.items()]\n",
     "print(fnames)"
    ]
   },
@@ -270,7 +270,7 @@
    "source": [
     "from bokeh.io import output_notebook\n",
     "import bokeh.plotting as bp\n",
-    "from bokeh.models import ColorBar, SingleIntervalTicker, FixedTicker, Range1d, Span\n",
+    "from bokeh.models import ColorBar, FixedTicker, Span\n",
     "from bokeh.palettes import Spectral10 as cm\n",
     "from bokeh.transform import linear_cmap\n",
     "\n",
@@ -419,7 +419,7 @@
     "    n = bp.figure(height=600, width=900, match_aspect=True)\n",
     "    \n",
     "    # Set up a linear color map based on the MJD data.\n",
-    "    mapper = linear_cmap(field_name='MJD', palette=cm ,low=min(mjd) ,high=max(mjd))\n",
+    "    mapper = linear_cmap(field_name='MJD', palette=cm, low=min(mjd), high=max(mjd))\n",
     "    \n",
     "    # Add lines to make 0 axis a bit more obvious.\n",
     "    lw = 1.3\n",
@@ -445,7 +445,7 @@
     "                         width=12,\n",
     "                         ticker=ticks,\n",
     "                         major_label_overrides=tick_dict,\n",
-    "                         location=(0,0), \n",
+    "                         location=(0, 0), \n",
     "                         label_standoff=45,\n",
     "                         )\n",
     "    n.add_layout(color_bar, 'right')\n",

--- a/notebooks/JWST/Engineering_Database_Retreival/requirements.txt
+++ b/notebooks/JWST/Engineering_Database_Retreival/requirements.txt
@@ -1,3 +1,3 @@
-bokeh >= 3.6.2
+bokeh >= 3.7.2
 numpy >= 1.23.5
 pandas >= 1.5.2


### PR DESCRIPTION
Newest version of `bokeh` requires that we specify the radius of a circle, so I put in a calculation to assign the radius as the range of the x values divided by 100. This way, the size of the circles will be consistent across the different split timeseries.