### PR TITLE
Spitzer fix for historical quasars notebook

### DIFF
--- a/notebooks/multi_mission/historic_quasar_observations/historic_quasar_observations.ipynb
+++ b/notebooks/multi_mission/historic_quasar_observations/historic_quasar_observations.ipynb
@@ -192,11 +192,14 @@
     "# Get the average wavelength\n",
     "wavelength_avg = (wavelength_max+wavelength_min)/2\n",
     "\n",
-    "# Some older missions have wavelengths that are off by a factor of 10^9\n",
+    "# Some older missions have wavelengths that are off by a factor of 10^9,\n",
+    "# and some observations have invalid wavelength ranges that were masked by numpy above.\n",
     "waves = []\n",
     "for wave in wavelength_avg:\n",
-    "    if wave/1e9 >= 1:\n",
-    "        waves.append(wave/1e9)\n",
+    "    if type(wave) is np.ma.core.MaskedConstant:\n",
+    "        waves.append(np.nan)  # If invalid, append NaN\n",
+    "    elif wave/1e9 >= 1:\n",
+    "        waves.append(wave/1e9)  # If >10^9, convert from m to nm\n",
     "    else:\n",
     "        waves.append(wave)\n",
     "        \n",
@@ -250,9 +253,7 @@
    "source": [
     "## Plotting Historical Observation Coverage\n",
     "\n",
-    "We want to visualize the history of observations of **3c273** according to the wavelength of the observation. We'll change the color and shape of each point to indicate which mission made the observation. \n",
-    "\n",
-    "**Note:** Since the wavelength data MAST spans a broad range of values, we'll plot our y-axis logarithmically."
+    "We want to visualize the history of observations of **3c273** according to the wavelength of the observation. We'll change the color and shape of each point to indicate which mission made the observation. "
    ]
   },
   {
@@ -278,55 +279,7 @@
     "    # Filter times and wavelengths by mission name\n",
     "    ind = np.where(mission == i)\n",
     "    # Plot the mission in its color as a scatterplot\n",
-    "    ax.scatter(times[ind], np.log(meter_waves[ind]), label=i, s=100, marker=next(marker))\n",
-    "\n",
-    "\n",
-    "# Place the legend\n",
-    "plt.legend()  \n",
-    "\n",
-    "# Set the label of the x and y axes\n",
-    "plt.xlabel(\"Time of Observation [Year]\", fontsize=15)\n",
-    "plt.ylabel(\"log(Wavelength of Observation [meters])\", fontsize=15)\n",
-    "\n",
-    "# Show the plot\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ac49dd09-431a-41f5-9d0d-92982d523e7f",
-   "metadata": {},
-   "source": [
-    "Incredible! There are many observations across the wavelength spectrum, going back to the 1970s.\n",
-    "\n",
-    "Since approximately half of this range is taken up by Spitzer, let's create a new plot focused on near-optical data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "07743a5d-a14a-48d9-b9d9-767523e2976e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Initialize the figure\n",
-    "fig = plt.figure()\n",
-    "fig.set_size_inches(15, 10)\n",
-    "ax = fig.add_subplot()\n",
-    "        \n",
-    "# Set a color for every unique mission name\n",
-    "cm = mpl.colormaps[\"plasma\"]\n",
-    "num_colors = len(np.unique(mission))\n",
-    "ax.set_prop_cycle(color=[cm(1.*i/num_colors) for i in range(num_colors)])\n",
-    "marker = itertools.cycle(('^', 'o', 's', '*')) \n",
-    "\n",
-    "# Loop through the mission names\n",
-    "for i in np.unique(mission):\n",
-    "    # Filter times and wavelengths by mission name\n",
-    "    ind = np.where(mission == i)\n",
-    "    # Plot the mission in its color as a scatterplot\n",
-    "    if i != \"SPITZER_SHA\":\n",
-    "        ax.scatter(times[ind], nm_waves[ind], label=i, s=100, marker=next(marker))\n",
+    "    ax.scatter(times[ind], meter_waves[ind], label=i, s=100, marker=next(marker))\n",
     "\n",
     "\n",
     "# Place the legend\n",
@@ -342,10 +295,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ac49dd09-431a-41f5-9d0d-92982d523e7f",
+   "metadata": {},
+   "source": [
+    "Incredible! There are many observations across the wavelength spectrum, going back to the 1970s."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab8117e9-f006-46d8-8e78-a9fcfb6c962a",
    "metadata": {},
    "source": [
-    "This gives us a much better view of the wavelength coverage near the optical regime. We have good coverage here, thanks to Hubble. Let's take a look at some of this data and create a spectrum."
+    "Let's take a look at some of this data and create a spectrum."
    ]
   },
   {
@@ -666,7 +627,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/multi_mission/historic_quasar_observations/historic_quasar_observations.ipynb
+++ b/notebooks/multi_mission/historic_quasar_observations/historic_quasar_observations.ipynb
@@ -199,7 +199,7 @@
     "    if type(wave) is np.ma.core.MaskedConstant:\n",
     "        waves.append(np.nan)  # If invalid, append NaN\n",
     "    elif wave/1e9 >= 1:\n",
-    "        waves.append(wave/1e9)  # If >10^9, convert from m to nm\n",
+    "        waves.append(wave/1e9)  # If off by 10^9, correct\n",
     "    else:\n",
     "        waves.append(wave)\n",
     "        \n",


### PR DESCRIPTION
Super trivial fixes following removal of Spitzer data from MAST cone searches yesterday.

--Spitzer data has been removed from MAST cone searches, so no need to exclude it anymore. Skip to plotting in linear wavelength, drop extra cell where Spitzer was cut, remove related text

--While I'm at it, check for numpy-masked values of wavelength_avg to suppress pre-existing numpy warning