### PR TITLE
Fixed Markdown cells for HTML rendering

### DIFF
--- a/notebooks/SDSS/eBOSS_HST_hubbles_law/hubbles_law.ipynb
+++ b/notebooks/SDSS/eBOSS_HST_hubbles_law/hubbles_law.ipynb
@@ -293,7 +293,9 @@
    "outputs": [],
    "source": [
     "# Downloading the full spectra products\n",
-    "manifest = Observations.download_products(products, mrp_only=True)"
+    "manifest = Observations.download_products(\n",
+    "    products, mrp_only=True, verbose=False\n",
+    ")"
    ]
   },
   {
@@ -423,14 +425,16 @@
    "metadata": {},
    "source": [
     "Since Hubble's constant is in units km/s/Mpc, we want to convert redshift to velocity. To do this, we can use the relativistic radial velocity equation [[5]](https://ned.ipac.caltech.edu/level5/Hogg/Hogg3.html): <br>\n",
+    "\n",
     "$$\n",
     "v = c \\frac{(1+z)^2-1}{(1+z)^2+1}\n",
     "$$\n",
     "\n",
     "Using error propagation, the error in redshift becomes: <br>\n",
+    "\n",
     "$$\n",
     "v_{err} = z_{err}|\\frac{4c(1+z)}{((1+z)^2+1)^2}|\n",
-    "$$"
+    "$$\n"
    ]
   },
   {
@@ -539,7 +543,9 @@
    "source": [
     "# Gathering and downloading full spectra files\n",
     "products2 = Observations.get_product_list(combined_results2)\n",
-    "manifest2 = Observations.download_products(products2, mrp_only=True)\n",
+    "manifest2 = Observations.download_products(\n",
+    "    products2, mrp_only=True, verbose=False\n",
+    ")\n",
     "\n",
     "# Writing data to an array\n",
     "abell_array = []\n",
@@ -612,9 +618,11 @@
    "metadata": {},
    "source": [
     "Now that we have filtered out both datasets, we can normalize the relative distances. To do this, we'll set up a ratio such that the closest galaxy in the Abell 2199 cluster equals 1:\n",
+    "\n",
     "$$\n",
     "\\frac{d_{1}}{d_{relative}} = \\frac{1}{d_{norm}}\n",
     "$$\n",
+    "\n",
     "where $d_{1}$ is the relative distance of the closest Abell 2199 galaxy, $d_{relative}$ is the array of relative distances of the eBOSS galaxies, and $d_{norm}$ is the array of normalized distances. To solve for the array of $d_{norm}$, we'll divide the array of relative distances by $d_{1}$. [[4]](https://skyserver.sdss.org/dr12/en/proj/advanced/hubble/distances.aspx)\n",
     "\n",
     "Since we know the distance to Abell 2199 is 128 Mpc, we'll multiply the normalized distances by 128 Mpc to obtain the actualized distances. [[6]](http://ned.ipac.caltech.edu/cgi-bin/nph-objsearch?objname=Abell+2199&extend=no&hconst=73&omegam=0.27&omegav=0.73&corr_z=1&out_csys=Equatorial&out_equinox=J2000.0&obj_sort=RA+or+Longitude&of=pre_text&zv_breaker=30000.0&list_limit=5&img_stamp=YES).\n"
@@ -630,7 +638,7 @@
     "sorted_abell = np.argsort(distance_velocity_array_abell[:, 0])\n",
     "sorted_abell_array = distance_velocity_array_abell[sorted_abell]\n",
     "\n",
-    "# We'll take the first Abell 2199 galaxy and find the average, then set that to 1\n",
+    "# Taking the first Abell 2199 galaxy and find the average, setting that to 1\n",
     "d1_abell = sorted_abell_array[0][0]\n",
     "\n",
     "# Normalize distances to d1_abell\n",


### PR DESCRIPTION
Completed Hubble's Law notebook, but the HTML rendering did not display some Markdown cells correctly. I added some spaces between equation blocks as well as removed the download outputs. 