### PR TITLE
Update the Kepler beginner notebook description

### DIFF
--- a/notebooks/Kepler/beginner.md
+++ b/notebooks/Kepler/beginner.md
@@ -3,7 +3,7 @@ This is a good place to get started if you're new to the Kepler mission or the l
 
 | Notebook                       | Description                                                                                                                           |
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| Plotting Lightcurves           | Create light curves from Kepler data using the popular light**k**urve package.                                                        |
+| Plotting Lightcurves           | Load and extract information from Kepler files, and plot light curves and the photometric aperture.                                   |
 | Plotting Images from TPF       | Use Kepler Target Pixel Files (TPF) to create images of targets.                                                                      |
 | Plotting a DVT File            | Load and plot a data validation timeseries (DVT) file.                                                                                |
 | Plotting a Catalog over an FFI | Use the [WCS](https://docs.astropy.org/en/stable/wcs/index.html) from a Full Frame Image (FFI) to to overlay an image from a catalog. |


### PR DESCRIPTION
Update the Kepler beginner notebook description for the "Plot light curves" notebook to accurately reflect the contents (plotting in that notebook is with only with matplotlib; all lightkurve notebooks are in a separate section).