### PR TITLE
Add PS1 20 queries spatial binning notebook

### DIFF
--- a/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.ipynb
+++ b/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.ipynb
@@ -317,7 +317,7 @@
     "            & (np.abs(TAP_results_q12['dec'] - decg) < 1e-2)\n",
     "        )[0]\n",
     "        if len(whm) > 0:\n",
-    "            bincounts[i,j] = TAP_results_q12['pop'][whm[0]]"
+    "            bincounts[i, j] = TAP_results_q12['pop'][whm[0]]"
    ]
   },
   {
@@ -334,7 +334,7 @@
    "outputs": [],
    "source": [
     "f, ax = plt.subplots()\n",
-    "f.set_size_inches(4,4)\n",
+    "f.set_size_inches(4, 4)\n",
     "\n",
     "im = ax.imshow(\n",
     "    bincounts, \n",
@@ -342,7 +342,7 @@
     "    origin=\"lower\", \n",
     "    interpolation=\"none\",\n",
     "    norm=PowerNorm(0.5),\n",
-    "    extent=(175,185,-5,5),\n",
+    "    extent=(175, 185, -5, 5),\n",
     ")\n",
     "divider = make_axes_locatable(ax)\n",
     "cax = divider.append_axes('right', size='5%', pad=0.05)\n",
@@ -419,7 +419,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "RightShift12 = np.power(4,12)   # Divisor to go from HTM IDs to the 8-deep HTM buckets\n",
+    "RightShift12 = np.power(4, 12)   # Divisor to go from HTM IDs to the 8-deep HTM buckets\n",
     "\n",
     "adql_query = f\"\"\"\n",
     "select (htmid/{RightShift12}) as htm_8, \n",
@@ -508,7 +508,7 @@
    "source": [
     "# Aitoff-projection scatter plot of HTM-8 bins\n",
     "\n",
-    "f = plt.figure(figsize=(10,5))\n",
+    "f = plt.figure(figsize=(10, 5))\n",
     "ax = f.add_axes([0.05, 0.05, 0.925, 0.9], projection=\"aitoff\")\n",
     "cax = f.add_axes([0.985, 0.05, 0.025, 0.9])\n",
     "\n",

--- a/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.ipynb
+++ b/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.ipynb
@@ -1,0 +1,639 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"top\"></a>\n",
+    "# PanSTARRS \"20 queries\" using MAST's TAP service: Spatial Binning\n",
+    "\n",
+    "\n",
+    "******\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "This notebook is part of a series demonstrating how to address a set of scientific questions using SQL-like Astronomical Data Query Language (ADQL) queries via a Virtual Observatory standard Table Access Protocol (TAP) service at MAST. \n",
+    "\n",
+    "This series aims to be an introduction to how complex queries can be executed using TAP (which might otherwise not be possible to specify with `astroquery`), and to be a resource for how to access MAST databases after the MAST CASJobs service is retired.\n",
+    "\n",
+    "The presented queries are drawn from 20 queries for SDSS as presented by [Gray, Szalay, et al. (2002)](https://arxiv.org/abs/cs/0202014), adapted for the PanSTARRS PS1 database.\n",
+    "\n",
+    "This notebook presents the subset of queries concerned with **obtaining spatially-binned counts of objects**, with both RA/Dec grids (with the local tangent plane approximation) and pre-computed hierarchical triangular mesh (HTM) ids combined with other filtering constraints.\n",
+    "\n",
+    "\n",
+    "## Learning Goals\n",
+    "By the end of this tutorial, you will:\n",
+    "\n",
+    "- Understand how to obtain counts of objects in spatial bins using ADQL queries with TAP services.\n",
+    "\n",
+    "\n",
+    "****\n",
+    "### Table of Contents\n",
+    "\n",
+    "1. [Introduction](#Introduction)\n",
+    "1. [Imports](#Imports)\n",
+    "1. [Connect to TAP service](#Connect-to-TAP-service)\n",
+    "1. [Q12: Create a gridded count of galaxies with g-r>1 and i<22.5 over -5<declination<5, and 175<right ascension<185, on a grid of 2’ arc minutes.](#Q12)\n",
+    "1. [Q13: Create a count of galaxies for each of the HTM triangles which satisfy a certain color cut, like 0.7g-0.5r-0.2i<1.25 and i<22.5, output it in a form adequate for visualization.](#Q13)\n",
+    "1. [Additional Resources](#Additional-Resources)\n",
+    "1. [About This Notebook](#About-this-Notebook)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "*******\n",
+    "## Introduction\n",
+    "\n",
+    "Welcome! This notebook demonstrates how to answer example scientific questions by performing SQL-like Astronomical Data Query Language (ADQL) queries accessing the PanSTARRS catalogs at MAST through a Virual Observatory Table Access Protocol (TAP) service.\n",
+    "\n",
+    "This tutorial will demonstrate how to answer two scientific questions that rely on obtaining counts of objects in spatial bins (together with relevant selection criteria filtering).\n",
+    "\n",
+    "These queries are taken from (or closely modeled on) the \"20 queries for SDSS\" presented by [Gray, Szalay, et al. (2002)](https://arxiv.org/abs/cs/0202014). Taken as a whole, this collection provides worked examples on how to leverage relational database capabilities to answer scientific questions, with the aim of providing concrete starting points and references for designing queries in other research applications, both for PanSTARRS and other large data volume missions (including Roman).\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> ADQL/SQL comments follow \"--\". Comments are used throughout the queries to explain the purpose of specific clauses.\n",
+    "</div>\n",
+    "\n",
+    "The workflow for this notebook consists of:\n",
+    "* [Main](#Main)\n",
+    "* [Connect to TAP service](#Connect-to-TAP-service)\n",
+    "* [Q12: Create a gridded count of galaxies with g-r>1 and i<22.5 over -5<declination<5, and 175<right ascension<185, on a grid of 2’ arc minutes.](#Q12)\n",
+    "  * [Constructing the query](#Q12:-Constructing-the-query)\n",
+    "  * [Inspecting & visualizing the results](#Q12:-Inspecting-&-visualizing-the-results)\n",
+    "* [Q13: Create a count of galaxies for each of the HTM triangles which satisfy a certain color cut, like 0.7g-0.5r-0.2i<1.25 and i<22.5, output it in a form adequate for visualization.](#Q13)\n",
+    "  * [Constructing the query](#Q13:-Constructing-the-query)\n",
+    "  * [Inspecting & visualizing the results](#Q13:-Inspecting-&-visualizing-the-results)\n",
+    "* [Additional Resources](#Additional-Resources)\n",
+    "* [About This Notebook](#About-this-Notebook)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Imports\n",
+    "This tutorial makes use of the following libraries: \n",
+    "- [*numpy*](https://numpy.org/) for numerical calculations\n",
+    "- [*pyvo*](https://pyvo.readthedocs.io) for querying the MAST catalogs via TAP\n",
+    "- [*matplotlib.pyplot*](https://matplotlib.org/stable/api/pyplot_summary.html#module-matplotlib.pyplot), [*PowerNorm*](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.PowerNorm.html), [*ScalarFormatter*](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.ScalarFormatter), [*MultipleLocator*](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.MultipleLocator), [*make_axes_locatable*](https://matplotlib.org/stable/api/_as_gen/mpl_toolkits.axes_grid1.axes_divider.make_axes_locatable.html), [*astropy.coordinates.Angle*](https://docs.astropy.org/en/stable/api/astropy.coordinates.Angle.html), [*astropy.units*](https://docs.astropy.org/en/stable/units/ref_api.html#module-astropy.units),   for plotting data\n",
+    "- *time*, *datetime* to determine query duration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pyvo as vo\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import PowerNorm\n",
+    "from matplotlib.ticker import MultipleLocator, ScalarFormatter\n",
+    "from astropy.coordinates import Angle\n",
+    "from astropy import units as u\n",
+    "from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable\n",
+    "import datetime\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "--------\n",
+    "## Connect to TAP service\n",
+    "\n",
+    "For all queries, we will be connecting to the Pan-STARRS (PS1) Data release 2 (DR2) catalog. Specifically, we will use the `ps1_dr2` catalogs available from the new [postgres-backed TAP service](https://mast.stsci.edu/vo-tap/api/v0.1/mast_catalogs/), which offers improved performance relative to the legacy database (by factors of 100 or greater, in many cases).\n",
+    "\n",
+    "See the [PS1 documentation](link_to_migration_guide_here) for information about the tables available with this new TAP service.\n",
+    "    \n",
+    "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
+    "<b>FIX LINK TO MIGRATION GUIDE ABOVE</b>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TAP_service = vo.dal.TAPService(\n",
+    "    \"https://mast.stsci.edu/vo-tap/api/v0.1/mast_catalogs\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This service supports the following ADQL features, \n",
+    "and will return up to 100,000 rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TAP_service.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
+    "The schemas for the PS1 DR2 tables are available at: https://mastdev.stsci.edu/schema_browser/#/\n",
+    "    <p></p>\n",
+    "</div>\n",
+    "\n",
+    "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
+    "<i><b>**IF POSSIBLE:**</b></i>\n",
+    "<i>Integrete the schema browser.</i>\n",
+    "\n",
+    "<i>Or else provide a simple URL link, so users can still use the schema browser even if it isn't fully integrated with the jupyter notebook?</i>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*********\n",
+    "\n",
+    "## Q12\n",
+    "\n",
+    "Following [Gray et al. (2002)](https://arxiv.org/abs/cs/0202014), but modifying by shifting one filter to the red (as PS1 has no `u` filter) and pushing one magnitude fainter (as PS1 is deeper than SDSS),  Query 12 poses: \n",
+    "\n",
+    "> **Create a gridded count of galaxies with g-r>1 and i<22.5 over -5<declination<5, and 175<right ascension<185, on a grid of 2’ arc minutes.**\n",
+    "\n",
+    "*(Note that we also omit the \"create a mask of the gridded region\" portion described by Gray et al., as it is unclear how to translate this for PS1. Additionally, the included cuts help to mitigate contamination from non-galaxies or data artifacts.)*\n",
+    "\n",
+    "### Q12: Constructing the query\n",
+    "\n",
+    "\n",
+    "In order to select galaxies down to such a faint magnitude limit, it is necessary to use the [`ps1_dr2.stack_object` table](link_to_migration_guide), which is based on the co-addition of all available images. This table provides all required information: object positions, Kron magnitudes (to capture galaxies' entire fluxes, versus PSF or aperture magnitudes), stack detection \"primary\" and \"best\" quality information, and PSF magnitudes (together with Kron magnitudes, separates galaxies from point sources).\n",
+    "\n",
+    "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
+    "Add correct link to the migration guide in the above paragraph.\n",
+    "</div>\n",
+    "\n",
+    "Constructing this query requires both (1) filtering to select only galaxies satsifying these color and magnitude criteria, and then (2) specifying how to bin up the results.\n",
+    "\n",
+    "\n",
+    "First, we apply selection criteria as follows:\n",
+    "- We apply cuts on RA and Dec to restrict to only objects in the specified region.\n",
+    "- We then apply the color and magnitude constraints (`gkronmag-rkronmag > 1` and `ikronmag < 22.5`).\n",
+    "- Finally, we apply cuts to reduce contamination and apply quality controls:\n",
+    "    - Require entries to both be marked as a `primarydetection`and the `bestdetection` in the `ps1_dr2.stack_object` table (`primarydetection > 0`, `bestdetection > 0`)\n",
+    "    - Require the sum of the `g`, `r`, `i` magnitudes to be greater than 0 (filtering out objects with missing photometry in any of these bands, denoted with values of -999)\n",
+    "    - Select only extended sources (using `ipsfmag > 0` and `(ipsfmag-ikronmag > 0.05)`)\n",
+    "\n",
+    "Next, we define our binning grid. This requires projecting the on-sky positions onto a plane which can then be gridded as specified. \n",
+    "In a local tangent plane, `RA*cos(Dec)` is a \"linear\" degree, while declination can be used as-is. Thus, we bin over a grid in`ramean*cos(decmean)` and `decmean` using a \"group by\" statement, centering the grid boundary definitions (achieved through rounding) on the center of the target region (`ramean=180, decmean=0`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Binning factor, to accomplish 2 arcmin bins.\n",
+    "bfac = 30.\n",
+    "# Midpoint RA value\n",
+    "ramid = 180.\n",
+    "\n",
+    "adql_query = f\"\"\"\n",
+    "select\n",
+    "   round((ramean-{ramid})*cos(radians(decmean))*{bfac},0)/{bfac}+{ramid} as racosdec,\n",
+    "   round(decmean*{bfac},0)/{bfac} as dec,\n",
+    "   count(*) as pop \n",
+    "from ps1_dr2.stack_object as s\n",
+    "where ramean between 175 and 185\n",
+    "   and decmean between -5 and 5\n",
+    "   and primarydetection>0                      -- keep best stack objects\n",
+    "   and bestdetection>0\n",
+    "   and (gkronmag+rkronmag+ikronmag) > 0        -- remove -999 values\n",
+    "   and ipsfmag>0 and (ipsfmag-ikronmag > 0.05) -- extended sources (galaxies)\n",
+    "   and gkronmag-rkronmag > 1                   -- color constraint\n",
+    "   and ikronmag < 22.5                         -- faint magnitude limit\n",
+    "group by\n",
+    "   round((ramean-{ramid})*cos(radians(decmean))*{bfac},0)/{bfac}+{ramid},\n",
+    "   round(decmean*{bfac},0)/{bfac}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then submit (and time) this query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = time.time()\n",
+    "job = TAP_service.run_async(adql_query)\n",
+    "end = time.time()\n",
+    "print(f\"Elapsed time: {str(datetime.timedelta(seconds=end-start))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q12: Inspecting & visualizing the results\n",
+    "\n",
+    "This query takes about 2.5 minutes and returned 77,888 rows (spatial bins)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TAP_results_q12 = job.to_table()\n",
+    "TAP_results_q12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then visualize the binned counts, by reformatting the query bin cell counts into a 2D numpy array for plotting.\n",
+    "\n",
+    "We accomplish this by first creating a grid of Dec, RA*cos(Dec) (the \"linear\" degree in this local tangent plane) describing the bin center positions, then creating an empty 2D array and assigning the bin count values from our query results based on the bin center locations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a grid of Dec, RA*cos(Dec) with spacing of 2 arcmin,\n",
+    "# specifying the center of each bin.\n",
+    "\n",
+    "ra_range = [175, 185]\n",
+    "dec_range = [-5, 5]\n",
+    "n_bins_ra = int((ra_range[1]-ra_range[0])/(2./60.)) + 1      # Add 1 for endpoint\n",
+    "n_bins_dec = int((dec_range[1]-dec_range[0])/(2./60.)) + 1   # Add 1 for endpoint\n",
+    "\n",
+    "dec_grid = np.linspace(dec_range[0], dec_range[1], num=n_bins_dec, endpoint=True)\n",
+    "racosdec_grid = np.linspace(ra_range[0], ra_range[1], num=n_bins_ra, endpoint=True)\n",
+    "\n",
+    "# Create an empty bincounts array\n",
+    "bincounts = np.zeros((n_bins_dec, n_bins_ra), dtype=int)\n",
+    "\n",
+    "# Get bincount values from query results:\n",
+    "for i, decg in enumerate(dec_grid):\n",
+    "    for j, racosdecg in enumerate(racosdec_grid):\n",
+    "        whm = np.where(\n",
+    "            (np.abs(TAP_results_q12['racosdec'] - racosdecg) < 1e-2)\n",
+    "            & (np.abs(TAP_results_q12['dec'] - decg) < 1e-2)\n",
+    "        )[0]\n",
+    "        if len(whm) > 0:\n",
+    "            bincounts[i,j] = TAP_results_q12['pop'][whm[0]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now visualize these bin counts by plotting this 2D array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, ax = plt.subplots()\n",
+    "f.set_size_inches(4,4)\n",
+    "\n",
+    "im = ax.imshow(\n",
+    "    bincounts, \n",
+    "    cmap=\"gist_heat\", \n",
+    "    origin=\"lower\", \n",
+    "    interpolation=\"none\",\n",
+    "    norm=PowerNorm(0.5),\n",
+    "    extent=(175,185,-5,5),\n",
+    ")\n",
+    "divider = make_axes_locatable(ax)\n",
+    "cax = divider.append_axes('right', size='5%', pad=0.05)\n",
+    "f.colorbar(im, cax=cax)\n",
+    "ax.set_xlim(ax.get_xlim()[::-1])\n",
+    "ax.set_xlabel('RA [RA*cos(Dec); deg]')\n",
+    "ax.set_ylabel('Dec [deg]')\n",
+    "ax.set_title('Q12: Galaxy counts in 2-arcmin bins')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In total, 217,725 galaxies are included in the binned counts.\n",
+    "\n",
+    "The bins in this region contain an average of only 2.8 galaxies, with a peak value at 24 counts (and a number of bins with no galaxies)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Summary statistics:\n",
+    "print(f\"Total galaxies: {np.sum(TAP_results_q12['pop'])}\")\n",
+    "print(f\"Average galaxies per bin: {np.sum(TAP_results_q12['pop'])/len(TAP_results_q12):0.1f}\")\n",
+    "print(f\"Peak value: {np.max(TAP_results_q12['pop'])} counts\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*********\n",
+    "\n",
+    "## Q13\n",
+    "\n",
+    "Following Gray et al., but modifying again by shifting one filter to the red (as PS1 has no `u` filter) and pushing one magnitude fainter (PS1 is deeper than SDSS), Query 13 poses:\n",
+    "\n",
+    "> **Create a count of galaxies for each of the HTM triangles which satisfy a certain color cut, like 0.7g-0.5r-0.2i<1.25 and i<22.5, output it in a form adequate for visualization.**\n",
+    "\n",
+    "\n",
+    "### Q13: Constructing the query\n",
+    "\n",
+    "As with Q12, selecting faint galaxies requires using the [`ps1_dr2.stack_object` table](link_to_migration_guide). \n",
+    "Again this table provides all the columns required for this query: hierarchical triangular mesh (HTM) ids, Kron magnitudes (to capture galaxies' entire fluxes, versus PSF or aperture magnitudes, PSF magnitudes (together with Kron magnitudes, separates galaxies from point sources), and stack detection \"primary\" and \"best\" quality information.\n",
+    "\n",
+    "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
+    "Add correct link to the migration guide in the above paragraph.\n",
+    "</div>\n",
+    "\n",
+    "Similar to the above example, this query will combine filtering and binning --- but in this case, the binning is greatly simplified as we can directly use the HTM ids which are available for all entries in the `stack_object` table.\n",
+    "\n",
+    "\n",
+    "We apply selection criteria to:\n",
+    "- Apply the color and magnitude constraints (`(0.7*gkronmag-0.5*rkronmag-0.2*ikronmag) < 1.25` and `ikronmag < 22.5`).\n",
+    "- Apply quality cuts and remove contamination:\n",
+    "    - Require entries to both be marked as a `primarydetection`and the `bestdetection` in the `ps1_dr2.stack_object` table (`primarydetection > 0`, `bestdetection > 0`)\n",
+    "    - Require the sum of the `g`, `r`, `i` magnitudes to be greater than 0 (filtering out objects with missing photometry in any of these bands, denoted with values of -999)\n",
+    "    - Select only extended sources (using `ipsfmag > 0` and `(ipsfmag-ikronmag > 0.05)`\n",
+    "\n",
+    "We then bin over the set of the 8-deep HTM buckets (with each covering about 1 square degree) using a \"group by\" statement, retrieving the 8-deep HTM buckets by right-shifting the HTM ids by 12 (as specified by Gray et al.).\n",
+    "\n",
+    "For this example, we also restrict the RA range to be within [245, 330] degrees, to ensure the query does not exceed the row limits for the MAST TAP service.\n",
+    "\n",
+    "> (**Note:** If executing this query in chunks to cover the full sky, chunks over 8-deep HTM buckets should be chosen and *not* RA ranges, as RA ranges do not cleanly overlap our desired 8-deep HTM bucket tiling.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RightShift12 = np.power(4,12)   # Divisor to go from HTM IDs to the 8-deep HTM buckets\n",
+    "\n",
+    "adql_query = f\"\"\"\n",
+    "select (htmid/{RightShift12}) as htm_8, \n",
+    "avg(ramean) as ra, \n",
+    "avg(decmean) as dec,\n",
+    "count(*) as pop\n",
+    "from ps1_dr2.stack_object as s\n",
+    "where primarydetection>0 and bestdetection>0\n",
+    "  and (gkronmag+rkronmag+ikronmag) > 0                -- remove -999 values\n",
+    "  and (ipsfmag>0) and (ipsfmag-ikronmag > 0.05)       -- extended sources (galaxies)\n",
+    "  and (0.7*gkronmag-0.5*rkronmag-0.2*ikronmag) < 1.25 -- meeting this color cut\n",
+    "  and (ikronmag < 22.5)\n",
+    "and ramean between 245 and 330\n",
+    "group by (htmid/{RightShift12})\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then submit this query to the TAP service (and capture the elapsed time)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = time.time()\n",
+    "job = TAP_service.run_async(adql_query)\n",
+    "end = time.time()\n",
+    "print(f\"Elapsed time: {str(datetime.timedelta(seconds=end-start))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q13: Inspecting & visualizing the results\n",
+    "\n",
+    "This query takes about 2.5 minutes to run and returned 94,834 rows. \n",
+    "\n",
+    "To query the full sky PanSTARRS coverage (without RA range restrictions), it would take ~10.5 minutes to run the queries, and would result in ~400,000 total rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TAP_results_q13 = job.to_table()\n",
+    "TAP_results_q13"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In total, 45,530,164 galaxies are included in the binned counts (for this RA range)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TAP_results_q13[\"pop\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now visualize the binned counts. As these bins span a wide swath of the sky, we will display the bin counts as a scatter plot over an Aitoff projection, with each bin's point colored by the number of galaxies in that bin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Aitoff-projection scatter plot of HTM-8 bins\n",
+    "\n",
+    "f = plt.figure(figsize=(10,5))\n",
+    "ax = f.add_axes([0.05, 0.05, 0.925, 0.9], projection=\"aitoff\")\n",
+    "cax = f.add_axes([0.985, 0.05, 0.025, 0.9])\n",
+    "\n",
+    "counts = ax.scatter(\n",
+    "    Angle(TAP_results_q13['ra']*u.deg).wrap_at(180 * u.deg).radian,\n",
+    "    Angle(TAP_results_q13['dec']*u.deg).radian,\n",
+    "    c=TAP_results_q13['pop'],\n",
+    "    lw=0,\n",
+    "    s=2,\n",
+    "    norm=PowerNorm(0.5),\n",
+    "    cmap=\"plasma\",\n",
+    ")\n",
+    "\n",
+    "ax.grid(True)\n",
+    "f.colorbar(counts, cax=cax)\n",
+    "cax.yaxis.set_major_locator(MultipleLocator(1000))\n",
+    "cax.yaxis.set_major_formatter(ScalarFormatter())\n",
+    "\n",
+    "ax.set_xlabel('RA')\n",
+    "ax.set_ylabel('Dec')\n",
+    "ax.set_title(\"Q13: HTMid Gridding\", pad=15)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The distribution is fairly uniform, as expected for galaxies.  Near the plane of the Milky Way (the arc that runs from middle left, up to the north (in the RA slice we have selected --- the Galactic plane also runs back down to the lower right if repeated over the full sky) there are some variations seen.  The darker regions have a lower density of objects per sky area, which is a real effect due to absorption by dust near the plane of the galaxy (which reduces galaxy brightnesses and so reduces the counts).  \n",
+    "\n",
+    "The brighter regions are areas with very high stellar densities.  Those stars are often blended together with neighbors, which produces a catalog object that appears to be spatially extended.  Those objects are interpreted as galaxies and so get erroneously included in the counts.  These effects near the Milky Way would need to be corrected before using this sky density for scientific analysis (or they could simply be excluded from the sample).\n",
+    "\n",
+    "We do note that one complication with this example directly using HTM binning is that **HTM bins do not have equal area on the sky**. This leads to the (spherical) triangular color pattern imprinted on the astrophysical signal on the sky (as described above). It *is* be possible to correct for the bin-area discrepancies by calculating the sky area in each bin. However, functions to perform such calculations are not available with MAST's PS1 TAP service, so determining this factor has been omitted from this tutorial example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----------\n",
+    "\n",
+    "## Additional Resources\n",
+    "\n",
+    "### Table Access Protocol\n",
+    "\n",
+    "- IVOA standard for RESTful web service access to tabular data\n",
+    "- http://www.ivoa.net/documents/TAP/\n",
+    "\n",
+    "### PanSTARRS 1 DR 2\n",
+    "\n",
+    "- https://outerspace.stsci.edu/display/PANSTARRS/\n",
+    "\n",
+    "### Astronomical Query Data Language (2.0)\n",
+    "\n",
+    "- IVOA standard for querying astronomical data in tabular format, with geometric search support\n",
+    "- http://www.ivoa.net/documents/latest/ADQL.html\n",
+    "\n",
+    "### PyVO\n",
+    "\n",
+    "- an affiliated package for [astropy](https://www.astropy.org/)\n",
+    "- find and retrieve astronomical data available from archives that support standard IVOA virtual observatory service protocols.\n",
+    "- https://pyvo.readthedocs.io/en/latest/index.html\n",
+    "\n",
+    "\n",
+    "### Full list of MAST/TAP services\n",
+    "- A full list of available MAST TAP services can be found at:\n",
+    "- https://mast.stsci.edu/vo-tap\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Citations\n",
+    "If you use `astropy` for published research, please cite the\n",
+    "authors. Follow these links for more information about citing `astropy`:\n",
+    "\n",
+    "* [Citing `astropy`](https://www.astropy.org/acknowledging.html)\n",
+    "\n",
+    "If you use PanSTARRS data accessed through MAST for published research, \n",
+    "please include the following acknowledgements, found at the following links:\n",
+    "\n",
+    "* [Acknowledging PanSTARRS](https://archive.stsci.edu/publishing/mission-acknowledgements#section-895d38a0-86b3-4143-b521-6cc3312701f9)\n",
+    "* [Acknowledging MAST](https://archive.stsci.edu/gsc/mast_data_use.html)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## About this Notebook\n",
+    "\n",
+    "\n",
+    "**Author(s):**  Rick White, Sedona Price<br>\n",
+    "**Keyword(s):** Tutorial, TAP, pyvo, ADQL, Pan-STARRS <br>\n",
+    "**First Published:** 2026-06-05<br>\n",
+    "**Last Updated:** 2026-06-05\n",
+    "***\n",
+    "[Top of Page](#top)\n",
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/style-guides/master/guides/images/stsci-logo.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.ipynb
+++ b/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.ipynb
@@ -12,11 +12,7 @@
     "\n",
     "## Overview\n",
     "\n",
-    "This notebook is part of a series demonstrating how to address a set of scientific questions using SQL-like Astronomical Data Query Language (ADQL) queries via a Virtual Observatory standard Table Access Protocol (TAP) service at MAST. \n",
-    "\n",
-    "This series aims to be an introduction to how complex queries can be executed using TAP (which might otherwise not be possible to specify with `astroquery`), and to be a resource for how to access MAST databases after the MAST CASJobs service is retired.\n",
-    "\n",
-    "The presented queries are drawn from 20 queries for SDSS as presented by [Gray, Szalay, et al. (2002)](https://arxiv.org/abs/cs/0202014), adapted for the PanSTARRS PS1 database.\n",
+    "This notebook is part of a series demonstrating how to address a set of scientific questions using SQL-like Astronomical Data Query Language (ADQL) queries via a Virtual Observatory standard Table Access Protocol (TAP) service at MAST.  This series aims to be an introduction to how complex queries can be executed using TAP (which might otherwise not be possible to specify with `astroquery`), and to be a resource for how to access MAST databases after the MAST CASJobs service is retired. The presented queries are drawn from 20 queries for SDSS as presented by [Gray, Szalay, et al. (2002)](https://arxiv.org/abs/cs/0202014), adapted for the PanSTARRS PS1 database.\n",
     "\n",
     "This notebook presents the subset of queries concerned with **obtaining spatially-binned counts of objects**, with both RA/Dec grids (with the local tangent plane approximation) and pre-computed hierarchical triangular mesh (HTM) ids combined with other filtering constraints.\n",
     "\n",
@@ -721,7 +717,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.ipynb
+++ b/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.ipynb
@@ -20,6 +20,13 @@
     "\n",
     "This notebook presents the subset of queries concerned with **obtaining spatially-binned counts of objects**, with both RA/Dec grids (with the local tangent plane approximation) and pre-computed hierarchical triangular mesh (HTM) ids combined with other filtering constraints.\n",
     "\n",
+    "For more examples of filtering techniques in TAP queries (including using bitmask filtering for data quality cuts), please see the [PS1 \"20 queries\" Basic Filtering tutorial](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812201/Pan-STARRS1+data+archive+home+page).\n",
+    "\n",
+    "<!-- ../PS1_20q_filtering_tutorial/PS1_20q_basic_filtering_tutorial.html -->\n",
+    "\n",
+    "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
+    "<b>FIX LINK TO BASIC FILTERING NOTEBOOK ABOVE</b>\n",
+    "</div>\n",
     "\n",
     "## Learning Goals\n",
     "By the end of this tutorial, you will:\n",
@@ -30,14 +37,20 @@
     "****\n",
     "### Table of Contents\n",
     "\n",
-    "1. [Introduction](#Introduction)\n",
-    "1. [Imports](#Imports)\n",
-    "1. [Connect to TAP service](#Connect-to-TAP-service)\n",
-    "1. [Q12: Create a gridded count of galaxies with g-r>1 and i<22.5 over -5<declination<5, and 175<right ascension<185, on a grid of 2’ arc minutes.](#Q12)\n",
-    "1. [Q13: Create a count of galaxies for each of the HTM triangles which satisfy a certain color cut, like 0.7g-0.5r-0.2i<1.25 and i<22.5, output it in a form adequate for visualization.](#Q13)\n",
-    "1. [Additional Resources](#Additional-Resources)\n",
-    "1. [About This Notebook](#About-this-Notebook)\n",
-    "\n"
+    "* [Introduction](#Introduction)\n",
+    "* [Imports](#Imports)\n",
+    "* [Connect to TAP service](#Connect-to-TAP-service)\n",
+    "* [Obtaining information about PanSTARRS catalogs](#obtaining-information-about-panstarrs-catalogs)\n",
+    "* [Q12: Create a gridded count of galaxies with g-r>1 and i<22.5 over -5<declination<5, and 175<right ascension<185, on a grid of 2’ arc minutes.](#q12)\n",
+    "  * [Constructing the query](#q12:-constructing-the-query)\n",
+    "  * [Inspecting & visualizing the results](#q12:-inspecting-&-visualizing-the-results)\n",
+    "* [Q13: Create a count of galaxies for each of the HTM triangles which satisfy a certain color cut, like 0.7g-0.5r-0.2i<1.25 and i<22.5, output it in a form adequate for visualization.](#q13)\n",
+    "  * [Constructing the query](#q13:-Constructing-the-query)\n",
+    "  * [Inspecting & visualizing the results](#q13:-inspecting-&-visualizing-the-results)\n",
+    "* [Conclusions](#conclusions)\n",
+    "* [Additional Resources](#additional-resources)\n",
+    "* [Citations](#citations)\n",
+    "* [About This Notebook](#about-this-notebook)"
    ]
   },
   {
@@ -51,27 +64,13 @@
     "*******\n",
     "## Introduction\n",
     "\n",
-    "Welcome! This notebook demonstrates how to answer example scientific questions by performing SQL-like Astronomical Data Query Language (ADQL) queries accessing the PanSTARRS catalogs at MAST through a Virual Observatory Table Access Protocol (TAP) service.\n",
-    "\n",
-    "This tutorial will demonstrate how to answer two scientific questions that rely on obtaining counts of objects in spatial bins (together with relevant selection criteria filtering).\n",
+    "Welcome! This notebook shows how to query MAST's PanSTARRS data using Astronomical Data Query Language (ADQL). We address two scientific questions that rely on obtaining counts of objects in spatial bins (together with relevant selection criteria filtering). As you'll see in our examples, MAST uses a standard Table Access Protocol (TAP) to handle these queries.\n",
     "\n",
     "These queries are taken from (or closely modeled on) the \"20 queries for SDSS\" presented by [Gray, Szalay, et al. (2002)](https://arxiv.org/abs/cs/0202014). Taken as a whole, this collection provides worked examples on how to leverage relational database capabilities to answer scientific questions, with the aim of providing concrete starting points and references for designing queries in other research applications, both for PanSTARRS and other large data volume missions (including Roman).\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Note:</b> ADQL/SQL comments follow \"--\". Comments are used throughout the queries to explain the purpose of specific clauses.\n",
-    "</div>\n",
-    "\n",
-    "The workflow for this notebook consists of:\n",
-    "* [Main](#Main)\n",
-    "* [Connect to TAP service](#Connect-to-TAP-service)\n",
-    "* [Q12: Create a gridded count of galaxies with g-r>1 and i<22.5 over -5<declination<5, and 175<right ascension<185, on a grid of 2’ arc minutes.](#Q12)\n",
-    "  * [Constructing the query](#Q12:-Constructing-the-query)\n",
-    "  * [Inspecting & visualizing the results](#Q12:-Inspecting-&-visualizing-the-results)\n",
-    "* [Q13: Create a count of galaxies for each of the HTM triangles which satisfy a certain color cut, like 0.7g-0.5r-0.2i<1.25 and i<22.5, output it in a form adequate for visualization.](#Q13)\n",
-    "  * [Constructing the query](#Q13:-Constructing-the-query)\n",
-    "  * [Inspecting & visualizing the results](#Q13:-Inspecting-&-visualizing-the-results)\n",
-    "* [Additional Resources](#Additional-Resources)\n",
-    "* [About This Notebook](#About-this-Notebook)"
+    "</div>"
    ]
   },
   {
@@ -119,13 +118,17 @@
     "--------\n",
     "## Connect to TAP service\n",
     "\n",
-    "For all queries, we will be connecting to the Pan-STARRS (PS1) Data release 2 (DR2) catalog. Specifically, we will use the `ps1_dr2` catalogs available from the new [postgres-backed TAP service](https://mast.stsci.edu/vo-tap/api/v0.1/mast_catalogs/), which offers improved performance relative to the legacy database (by factors of 100 or greater, in many cases).\n",
+    "For all queries, we will be connecting to the PanSTARRS (PS1) Data release 2 (DR2) catalog. Specifically, we will use the `ps1_dr2` catalogs available from the new [postgres-backed TAP service](https://mast.stsci.edu/vo-tap/api/v0.1/mast_catalogs/), which offers improved performance relative to the legacy database (by factors of 100 or greater, in many cases).\n",
     "\n",
-    "See the [PS1 documentation](link_to_migration_guide_here) for information about the tables available with this new TAP service.\n",
+    "See the [PS1 documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812201/Pan-STARRS1+data+archive+home+page) for information about the tables available with this new TAP service.\n",
     "    \n",
     "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
     "<b>FIX LINK TO MIGRATION GUIDE ABOVE</b>\n",
-    "</div>"
+    "</div>\n",
+    "\n",
+    "We begin by connecting to the MAST PanSTARRS DR2 TAP service.\n",
+    "\n",
+    "_(Note: See https://mast.stsci.edu/vo-tap/ for a full list of MAST TAP services.)_"
    ]
   },
   {
@@ -143,8 +146,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This service supports the following ADQL features, \n",
-    "and will return up to 100,000 rows."
+    "Using the pyvo `describe()` method, we can access an overview of the methods, capabilities, and maximum result set size for this service. "
    ]
   },
   {
@@ -160,16 +162,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
-    "The schemas for the PS1 DR2 tables are available at: https://mastdev.stsci.edu/schema_browser/#/\n",
-    "    <p></p>\n",
-    "</div>\n",
+    "As expected, this service supports ADQL. You can also see the maximum result size is 100,000 rows."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Obtaining information about PanSTARRS catalogs\n",
+    "\n",
+    "In addition to the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs), \n",
+    "we can search and explore information about the PS1 DR2 tables using **MAST's [Catalog Schema Browser](https://mast.stsci.edu/schema_browser)**. This schema browser provides searchable listings of column names, units, and descriptions for the PS1 DR2 tables available via this TAP service. \n",
+    "\n",
+    "We draw on this documentation and schema browser to identify the relevant tables & columns needed to address the queries below.\n",
+    "\n",
     "\n",
     "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
     "<i><b>**IF POSSIBLE:**</b></i>\n",
     "<i>Integrete the schema browser.</i>\n",
-    "\n",
-    "<i>Or else provide a simple URL link, so users can still use the schema browser even if it isn't fully integrated with the jupyter notebook?</i>\n",
     "</div>"
    ]
   },
@@ -185,12 +195,12 @@
     "\n",
     "> **Create a gridded count of galaxies with g-r>1 and i<22.5 over -5<declination<5, and 175<right ascension<185, on a grid of 2’ arc minutes.**\n",
     "\n",
-    "*(Note that we also omit the \"create a mask of the gridded region\" portion described by Gray et al., as it is unclear how to translate this for PS1. Additionally, the included cuts help to mitigate contamination from non-galaxies or data artifacts.)*\n",
+    "Compared to the original Gray et al. Query 12, we omit the component to \"create a mask of the gridded region\", as it is unclear how to translate this for PS1. In our example, the included cuts help to mitigate contamination from non-galaxies or data artifacts.\n",
     "\n",
     "### Q12: Constructing the query\n",
     "\n",
     "\n",
-    "In order to select galaxies down to such a faint magnitude limit, it is necessary to use the [`ps1_dr2.stack_object` table](link_to_migration_guide), which is based on the co-addition of all available images. This table provides all required information: object positions, Kron magnitudes (to capture galaxies' entire fluxes, versus PSF or aperture magnitudes), stack detection \"primary\" and \"best\" quality information, and PSF magnitudes (together with Kron magnitudes, separates galaxies from point sources).\n",
+    "In order to select galaxies down to such a faint magnitude limit, it is necessary to use the [`ps1_dr2.stack_object` table](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812201/Pan-STARRS1+data+archive+home+page), which is based on the co-addition of all available images. This table provides all required information: object positions, Kron magnitudes (to capture galaxies' entire fluxes, versus PSF or aperture magnitudes), stack detection \"primary\" and \"best\" quality information, and PSF magnitudes (together with Kron magnitudes, separates galaxies from point sources).\n",
     "\n",
     "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
     "Add correct link to the migration guide in the above paragraph.\n",
@@ -207,8 +217,10 @@
     "    - Require the sum of the `g`, `r`, `i` magnitudes to be greater than 0 (filtering out objects with missing photometry in any of these bands, denoted with values of -999)\n",
     "    - Select only extended sources (using `ipsfmag > 0` and `(ipsfmag-ikronmag > 0.05)`)\n",
     "\n",
-    "Next, we define our binning grid. This requires projecting the on-sky positions onto a plane which can then be gridded as specified. \n",
-    "In a local tangent plane, `RA*cos(Dec)` is a \"linear\" degree, while declination can be used as-is. Thus, we bin over a grid in`ramean*cos(decmean)` and `decmean` using a \"group by\" statement, centering the grid boundary definitions (achieved through rounding) on the center of the target region (`ramean=180, decmean=0`)."
+    "We define our binning grid as follows.  This requires projecting the on-sky positions onto a plane which can then be gridded as specified. \n",
+    "In a local tangent plane, `RA*cos(Dec)` is a \"linear\" degree, while declination can be used as-is. Thus, we bin over a grid in`ramean*cos(decmean)` and `decmean` using a \"group by\" statement, centering the grid boundary definitions (achieved through rounding) on the center of the target region (`ramean=180, decmean=0`).\n",
+    "\n",
+    "Here we define variables used for our binning: a binning factor of 30 (to convert from degrees to units of 2 arcsecs, our intended bin size), and then the midpoint RA value, used for the local tangent plane projection."
    ]
   },
   {
@@ -220,8 +232,22 @@
     "# Binning factor, to accomplish 2 arcmin bins.\n",
     "bfac = 30.\n",
     "# Midpoint RA value\n",
-    "ramid = 180.\n",
-    "\n",
+    "ramid = 180."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now construct our query, implementing the constraints listed above. In addition to the bin count, we also return the derived bin center position (in the local tangent plane)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "adql_query = f\"\"\"\n",
     "select\n",
     "   round((ramean-{ramid})*cos(radians(decmean))*{bfac},0)/{bfac}+{ramid} as racosdec,\n",
@@ -246,7 +272,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then submit (and time) this query."
+    "We then submit (and time) this query to MAST's TAP service."
    ]
   },
   {
@@ -265,9 +291,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This query takes about 2.5 minutes, and returns 77,888 rows (each row containing the count for a single spatial bin)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Q12: Inspecting & visualizing the results\n",
     "\n",
-    "This query takes about 2.5 minutes and returned 77,888 rows (spatial bins)."
+    "To inspect our results, we convert the TAP results to an astropy table, for easy viewing."
    ]
   },
   {
@@ -284,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then visualize the binned counts, by reformatting the query bin cell counts into a 2D numpy array for plotting.\n",
+    "In order to visualize these binned counts, we will reformat this results table into a 2D numpy array that can be displayed with matplotlib.\n",
     "\n",
     "We accomplish this by first creating a grid of Dec, RA*cos(Dec) (the \"linear\" degree in this local tangent plane) describing the bin center positions, then creating an empty 2D array and assigning the bin count values from our query results based on the bin center locations."
    ]
@@ -357,9 +390,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In total, 217,725 galaxies are included in the binned counts.\n",
-    "\n",
-    "The bins in this region contain an average of only 2.8 galaxies, with a peak value at 24 counts (and a number of bins with no galaxies)."
+    "Finally, we compute some summary statistics (total galaxies, average galaxies per bin, and peak bin galaxy count)."
    ]
   },
   {
@@ -378,6 +409,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We see that in total, 217,725 galaxies are included in the binned counts. The bins in this region containing an average of only 2.8 galaxies, with a peak value of 24 counts, and a number of bins with no galaxies at all."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "*********\n",
     "\n",
     "## Q13\n",
@@ -389,7 +427,7 @@
     "\n",
     "### Q13: Constructing the query\n",
     "\n",
-    "As with Q12, selecting faint galaxies requires using the [`ps1_dr2.stack_object` table](link_to_migration_guide). \n",
+    "As with Q12, selecting faint galaxies requires using the [`ps1_dr2.stack_object` table](). \n",
     "Again this table provides all the columns required for this query: hierarchical triangular mesh (HTM) ids, Kron magnitudes (to capture galaxies' entire fluxes, versus PSF or aperture magnitudes, PSF magnitudes (together with Kron magnitudes, separates galaxies from point sources), and stack detection \"primary\" and \"best\" quality information.\n",
     "\n",
     "<div class=\"alert alert-warning\" style=\"color:red; background-color:#ffc5c5; border-color:red;\">\n",
@@ -410,7 +448,14 @@
     "\n",
     "For this example, we also restrict the RA range to be within [245, 330] degrees, to ensure the query does not exceed the row limits for the MAST TAP service.\n",
     "\n",
-    "> (**Note:** If executing this query in chunks to cover the full sky, chunks over 8-deep HTM buckets should be chosen and *not* RA ranges, as RA ranges do not cleanly overlap our desired 8-deep HTM bucket tiling.)"
+    "> _(**Note:** If executing this query in chunks to cover the full sky, chunks over 8-deep HTM buckets should be chosen and *not* RA ranges, as RA ranges do not cleanly overlap our desired 8-deep HTM bucket tiling.)_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first caluculate the divisor needed to determine 8-deep HTM buckets (which, as noted above, is accomplished by right-shift the HTM ids by 12)."
    ]
   },
   {
@@ -419,8 +464,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "RightShift12 = np.power(4, 12)   # Divisor to go from HTM IDs to the 8-deep HTM buckets\n",
-    "\n",
+    "RightShift12 = np.power(4, 12)   # Divisor to go from HTM IDs to the 8-deep HTM buckets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then construct an ADQL query combining the above filtering contstraints, and the 8-deep HTM bucket binning. In addition to the count of galaxies per bin, we return the 8-deep HTM bucket ID, and the average RA/Dec for each bin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "adql_query = f\"\"\"\n",
     "select (htmid/{RightShift12}) as htm_8, \n",
     "avg(ramean) as ra, \n",
@@ -441,7 +500,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then submit this query to the TAP service (and capture the elapsed time)."
+    "Again, we submit this query to the TAP service, and obtain the results."
    ]
   },
   {
@@ -460,11 +519,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This query takes about 2.5 minutes to run, and returns 94,834 rows.\n",
+    "\n",
+    "To query the full-sky PanSTARRS coverage (without RA range restrictions, but instead restricting by HTM-8 IDs), it would take ~10.5 minutes to run the queries, and would result in ~400,000 total rows."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Q13: Inspecting & visualizing the results\n",
     "\n",
-    "This query takes about 2.5 minutes to run and returned 94,834 rows. \n",
-    "\n",
-    "To query the full sky PanSTARRS coverage (without RA range restrictions), it would take ~10.5 minutes to run the queries, and would result in ~400,000 total rows."
+    "As before, we'll now convert our results to an astropy table."
    ]
   },
   {
@@ -481,7 +547,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In total, 45,530,164 galaxies are included in the binned counts (for this RA range)."
+    "We'll next compute the total number of galaxies in our results."
    ]
   },
   {
@@ -490,14 +556,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TAP_results_q13[\"pop\"].sum()"
+    "print(f\"Total number of galaxies: {TAP_results_q13[\"pop\"].sum()}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now visualize the binned counts. As these bins span a wide swath of the sky, we will display the bin counts as a scatter plot over an Aitoff projection, with each bin's point colored by the number of galaxies in that bin."
+    "For this RA range, our binned results contain a total of 45,530,164 galaxies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to Q12, we'll now visualize the binned counts.\n",
+    "\n",
+    "In this case, as our results span a wide swath of the sky, we will display the bin counts as a scatter plot over an Aitoff projection, coloring each bin's point by the number of galaxies in that bin."
    ]
   },
   {
@@ -536,11 +611,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The distribution is fairly uniform, as expected for galaxies.  Near the plane of the Milky Way (the arc that runs from middle left, up to the north (in the RA slice we have selected --- the Galactic plane also runs back down to the lower right if repeated over the full sky) there are some variations seen.  The darker regions have a lower density of objects per sky area, which is a real effect due to absorption by dust near the plane of the galaxy (which reduces galaxy brightnesses and so reduces the counts).  \n",
+    "We see that the bin count distribution is fairly uniform, as we expect for the distribution of galaxies within these relatively large bins.\n",
     "\n",
-    "The brighter regions are areas with very high stellar densities.  Those stars are often blended together with neighbors, which produces a catalog object that appears to be spatially extended.  Those objects are interpreted as galaxies and so get erroneously included in the counts.  These effects near the Milky Way would need to be corrected before using this sky density for scientific analysis (or they could simply be excluded from the sample).\n",
     "\n",
-    "We do note that one complication with this example directly using HTM binning is that **HTM bins do not have equal area on the sky**. This leads to the (spherical) triangular color pattern imprinted on the astrophysical signal on the sky (as described above). It *is* be possible to correct for the bin-area discrepancies by calculating the sky area in each bin. However, functions to perform such calculations are not available with MAST's PS1 TAP service, so determining this factor has been omitted from this tutorial example."
+    "Near the plane of the Milky Way (the arc that runs from middle left, up to the north (in the RA slice we have selected --- the Galactic plane also runs back down to the lower right if repeated over the full sky), however, we see some variations.  The darker regions have a lower density of objects per sky area, which is a real effect due to absorption by dust near the plane of the galaxy (which reduces galaxy brightnesses and so reduces the counts).\n",
+    "\n",
+    "The brighter regions are areas with very high stellar densities.  In PanSTARRS imaging, those stars are often blended together with neighbors, which produces a catalog object that appears to be spatially extended.  Those objects are interpreted as galaxies based on our selection criteria, and so get erroneously included in the counts.  These effects near the Milky Way would need to be corrected before using this sky density for scientific analysis (or these regions could simply be excluded from the sample).\n",
+    "\n",
+    "We do note one additional complication for this example, arising from our use of HTM binning: **HTM bins do not have equal area on the sky**. This leads to the (spherical) triangular color pattern imprinted on the astrophysical signal on the sky (as described above). It _is_ be possible to correct for the bin-area discrepancies by calculating the sky area in each bin. However, functions to perform such calculations are not available with MAST's PanSTARRS TAP service, so determining this factor has been omitted from this tutorial example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "------\n",
+    "\n",
+    "## Conclusions\n",
+    "\n",
+    "The queries above demonstrate the speed of MAST's new, more performant PS1 TAP service.  These specific queries are up to 4 times faster than is possible with MAST's CASJobs service. (Depending on the set of constraints specified, this service can have even greater speedups.)\n",
+    "\n",
+    "See the full MAST [PanSTARRS tutorial list](../../panstarrs.md) for more tutorials demonstrating how to access PanSTARRS catalogs and other select \"20 queries\" examples."
    ]
   },
   {
@@ -606,9 +697,8 @@
     "\n",
     "\n",
     "**Author(s):**  Rick White, Sedona Price<br>\n",
-    "**Keyword(s):** Tutorial, TAP, pyvo, ADQL, Pan-STARRS <br>\n",
-    "**First Published:** 2026-06-05<br>\n",
-    "**Last Updated:** 2026-06-05\n",
+    "**Keyword(s):** Tutorial, TAP, pyvo, ADQL, PanSTARRS <br>\n",
+    "**Last Updated:** August 2026\n",
     "***\n",
     "[Top of Page](#top)\n",
     "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/style-guides/master/guides/images/stsci-logo.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "

--- a/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/requirements.txt
+++ b/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/requirements.txt
@@ -1,0 +1,4 @@
+astropy >= 5.3.3
+matplotlib >= 3.7.1
+numpy >= 1.25.0
+pyvo >= 1.4.1

--- a/notebooks/PanSTARRS/PS1_20_query_tutorials/panstarrs_20_query_tutorials.md
+++ b/notebooks/PanSTARRS/PS1_20_query_tutorials/panstarrs_20_query_tutorials.md
@@ -1,0 +1,16 @@
+# Example "20 queries" with PanSTARRS
+
+## For Further Reading
+
+For information about Pan-STARRS and links to Pan-STARRS resources, please see [the Pan-STARRS landing page](https://spacetelescope.github.io/mast_notebooks/notebooks/PanSTARRS/panstarrs.html).
+
+## Notebooks in this Section
+
+The notebooks in this section demonstrate how to execute example science queries, grouped by technique & technical similarities. These queries are drawn from the 20 queries for SDSS as presented by [Gray, Szalay, et al. (2002)](https://arxiv.org/abs/cs/0202014), adapted for the Pan-STARRS PS1 database. In all, this series of notebooks will present the 11 queries which are applicable for PS1.
+
+
+| Notebook        | Description                                                                                                                                                  |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Pan-STARRS "20 queries": Spatial Binning](https://spacetelescope.github.io/mast_notebooks/notebooks/PanSTARRS/PS1_20_query_tutorials/PS1_20q_spatial_binning/PS1_20q_spatial_binning.html) | Tutorial demonstrating how to spatially bin (with selection criteria filtering) objects from the Pan-STARRS DR2 catalogs, using the Table Access Protocol (TAP) service at MAST. |
+
+More Pan-STARRS example query notebooks will be coming soon!

--- a/notebooks/PanSTARRS/panstarrs.md
+++ b/notebooks/PanSTARRS/panstarrs.md
@@ -1,0 +1,30 @@
+# Panoramic Survey Telescope and Rapid Response System (Pan-STARRS)
+
+## What is Pan-STARRS?
+[Panoramic Survey Telescope and Rapid Response System (Pan-STARRS)](http://pan-starrs.ifa.hawaii.edu/) is a system for wide-field astronomical imaging developed 
+and operated by the Institute for Astronomy at the University of Hawaii.
+Pan-STARRS1 (PS1) is the first part of Pan-STARRS to be completed and is the basis 
+for both Data Releases 1 and 2 (DR1 and DR2). 
+The PS1 survey used a 1.8 meter telescope and its 1.4 Gigapixel camera (GPC1; see 
+[PS1 GPC1 camera](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812301/PS1+GPC1+camera)) 
+to image the sky in five broadband [filters](https://outerspace.stsci.edu/display/PANSTARRS/PS1+Filter+properties) (g, r, i, z, y). The PS1 Science Consortium funded the operation of the Pan-STARRS1 telescope, situated at Haleakala Observatories near the summit of 
+Haleakala in Hawaii, for the purposes of astronomical research. 
+The PS1 consortium is made up of astronomers and engineers from 
+[14 institutions from six countries](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812469/PS1+Science+Consortium+-+PS1SC). 
+
+The data from PS1 are archived at the [Space Telescope Science Institute](http://www.stsci.edu/) (STScI) in Baltimore Maryland, and can be accessed through MAST, the Mikulski Archive for Space Telescopes (see the [Pan-STARRS1 Data Archive](https://outerspace.stsci.edu/display/PANSTARRS/Pan-STARRS1+data+archive+home+page)). Additional support for the PS1 public science archive is provided by the [Gordon and Betty Moore Foundation](https://www.moore.org/).
+
+## For Further Reading
+
+The [Pan-STARRS1 Data Archive at MAST](https://outerspace.stsci.edu/display/PANSTARRS/Pan-STARRS1+data+archive+home+page) website contains summary information, data product overviews, descriptions of MAST tools, and tutorials on how to interact with PS1 data at MAST.
+
+For more general information regarding Pan-STARRS1, see the [MAST Pan-STARRS1 homepage](https://archive.stsci.edu/missions-and-data/pan-starrs), and the [Pan-STARRS system homepage](http://pan-starrs.ifa.hawaii.edu/).
+
+## Notebooks in this Chapter
+
+
+| Notebook        | Description                                                                                                                                                  |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [MAST Table Access Protocol Pan-STARRS1 DR2 Tutorial](https://spacetelescope.github.io/mast_notebooks/notebooks/PanSTARRS/PS1_DR2_TAP/PS1_DR2_TAP.html) | Tutorial demonstrating how to access Pan-STARRS 1 Data Release 2 catalogs via a Virtual Observatory standard Table Access Protocol (TAP) service at MAST. |
+| [Retreiving Pan-STARRS images Tutorial](https://spacetelescope.github.io/mast_notebooks/notebooks/PanSTARRS/PS1_image/PS1_image.html) | Tutorial of how to programmatically retrieve Pan-STARRS1 image cutouts using the PS1 Image Server at MAST. |
+| [Pan-STARRS "20 queries" Tutorials](https://spacetelescope.github.io/mast_notebooks/notebooks/PanSTARRS/PS1_20_query_tutorials/panstarrs_20_query_tutorials.html) | Tutorials with examples of how to answer select scientify questions through queries to the PS1 DR2 catalogs using the Table Access Protocol (TAP) service at MAST. |


### PR DESCRIPTION
As part of the CASJobs sunsetting efforts, MAST will be providing notebooks demonstrating how to query the Pan-STARRS catalogs at MAST using TAP/ADQL as an alternative access method.

While a Pan-STARRS/TAP notebook already exists within the MAST notebooks, the set of Pan-STARRS "20 queries" (based on the SDSS 20 queries presented by Gray et al. 2002) as adapted and formulated by Rick White for CASJobs (available on innerspace) were identified as additional valuable examples.

This notebook presents the "spatial binning" subset of these "20 queries" for Pan-STARRS, covering queries mapping objects in spatial bins (over RA/Dec -- Q12; and in HTM bins -- Q13).


Overview pages for PS1 and the PS1 "20 query" tutorials have been added, following the style of the SDSS notebooks. (These will require merge editing given the other PS1 20 queries pull requests.)

As a note: two things will require editing before merging. Both items are flagged with big red boxes, which will be removed prior to merging:

- [ ] Verifying integration of the schema browser (and editing the narrative to describe how to access the schema browser), after it has been deployed publicly (as a URL) and is integrated in TIKE (through the jupyter hub instance).
- [ ] Adding correct URLs to the "PS1 TAP migration guide", describing differences in the MSSQL-backed and new, more-performant postgres-backed TAP service for PS1 DR2.