### PR TITLE
Fix broken STScI logo links in MAST notebooks

### DIFF
--- a/notebooks/HSC/HCV_CASJOBS/HCV_casjobs_demo.ipynb
+++ b/notebooks/HSC/HCV_CASJOBS/HCV_casjobs_demo.ipynb
@@ -945,7 +945,7 @@
     "**Last Updated:** May 2023 <br>\n",
     "***\n",
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/HSC/HSCV3_API/hscv3_api.ipynb
+++ b/notebooks/HSC/HSCV3_API/hscv3_api.ipynb
@@ -651,7 +651,7 @@
     "For support, please contact the Archive HelpDesk at archive@stsci.edu.\n",
     "***\n",
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/HSC/HSCV3_SMC_API/hscv3_smc_api.ipynb
+++ b/notebooks/HSC/HSCV3_SMC_API/hscv3_smc_api.ipynb
@@ -507,7 +507,7 @@
     "**Last Updated:** May 2023 <br>\n",
     "***\n",
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/HSC/HSC_TAP/HSC_TAP.ipynb
+++ b/notebooks/HSC/HSC_TAP/HSC_TAP.ipynb
@@ -407,7 +407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/JWST/Engineering_Database_Retreival/EDB_Retrieval.ipynb
+++ b/notebooks/JWST/Engineering_Database_Retreival/EDB_Retrieval.ipynb
@@ -498,7 +498,7 @@
     "For support, please contact the Archive HelpDesk at archive@stsci.edu.\n",
     "\n",
     "***\n",
-    " <img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n",
+    " <img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n",
     "\n",
     "[Return to top of page](#JWST-Engineering-Data-Retrieval)"
    ]

--- a/notebooks/JWST/MAST_metadata_search/MAST_metadata_search.ipynb
+++ b/notebooks/JWST/MAST_metadata_search/MAST_metadata_search.ipynb
@@ -596,7 +596,7 @@
     "\n",
     "***\n",
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/JWST/SI_keyword_exoplanet_search/SI_keyword_exoplanet_search.ipynb
+++ b/notebooks/JWST/SI_keyword_exoplanet_search/SI_keyword_exoplanet_search.ipynb
@@ -577,7 +577,7 @@
     "\n",
     "**Last updated:** May 2023\n",
     "\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/JWST/download_by_program_id/download_by_program_id.ipynb
+++ b/notebooks/JWST/download_by_program_id/download_by_program_id.ipynb
@@ -368,7 +368,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/K2/TPF/TPF.ipynb
+++ b/notebooks/K2/TPF/TPF.ipynb
@@ -340,7 +340,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/K2/beginner_how_to_use_ffi/beginner_how_to_use_ffi.ipynb
+++ b/notebooks/K2/beginner_how_to_use_ffi/beginner_how_to_use_ffi.ipynb
@@ -189,7 +189,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/K2/removing_instrumental_noise_using_pld/removing_instrumental_noise_using_pld.ipynb
+++ b/notebooks/K2/removing_instrumental_noise_using_pld/removing_instrumental_noise_using_pld.ipynb
@@ -664,7 +664,7 @@
     "id": "1i_uXbTNuYxF"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/creating_periodograms/creating_periodograms.ipynb
+++ b/notebooks/Kepler/creating_periodograms/creating_periodograms.ipynb
@@ -431,7 +431,7 @@
     "id": "OOnhHhZR9bXo"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/how_to_estimate_a_stars_mass_and_radius_using_asteroseismology/how_to_estimate_a_stars_mass_and_radius_using_asteroseismology.ipynb
+++ b/notebooks/Kepler/how_to_estimate_a_stars_mass_and_radius_using_asteroseismology/how_to_estimate_a_stars_mass_and_radius_using_asteroseismology.ipynb
@@ -834,7 +834,7 @@
     "id": "URWzHJMG_-ce"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star/how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star.ipynb
+++ b/notebooks/Kepler/how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star/how_to_understand_and_manipulate_the_periodogram_of_an_oscillating_star.ipynb
@@ -521,7 +521,7 @@
     "id": "OOnhHhZR9bXo"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/instrumental_noise_1_data_gaps_and_quality_flags/instrumental_noise_1_data_gaps_and_quality_flags.ipynb
+++ b/notebooks/Kepler/instrumental_noise_1_data_gaps_and_quality_flags/instrumental_noise_1_data_gaps_and_quality_flags.ipynb
@@ -623,7 +623,7 @@
     "id": "y1HbVfHwDVeN"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/Kepler/instrumental_noise_2_spurious_signals_and_time_sampling_effects/instrumental_noise_2_spurious_signals_and_time_sampling_effects.ipynb
+++ b/notebooks/Kepler/instrumental_noise_2_spurious_signals_and_time_sampling_effects/instrumental_noise_2_spurious_signals_and_time_sampling_effects.ipynb
@@ -502,7 +502,7 @@
     "id": "y1HbVfHwDVeN"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/Kepler/instrumental_noise_3_seasonal_and_detector_effects/instrumental_noise_3_seasonal_and_detector_effects.ipynb
+++ b/notebooks/Kepler/instrumental_noise_3_seasonal_and_detector_effects/instrumental_noise_3_seasonal_and_detector_effects.ipynb
@@ -389,7 +389,7 @@
     "id": "y1HbVfHwDVeN"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/Kepler/instrumental_noise_4_electronic_noise/instrumental_noise_4_electronic_noise.ipynb
+++ b/notebooks/Kepler/instrumental_noise_4_electronic_noise/instrumental_noise_4_electronic_noise.ipynb
@@ -381,7 +381,7 @@
     "id": "y1HbVfHwDVeN"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/Kepler/lightkurve_analyzing_lc_products/lightkurve_analyzing_lc_products.ipynb
+++ b/notebooks/Kepler/lightkurve_analyzing_lc_products/lightkurve_analyzing_lc_products.ipynb
@@ -1198,7 +1198,7 @@
     "id": "CNf3nI0trtA-"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/lightkurve_analyzing_tpf_products/lightkurve_analyzing_tpf_products.ipynb
+++ b/notebooks/Kepler/lightkurve_analyzing_tpf_products/lightkurve_analyzing_tpf_products.ipynb
@@ -957,7 +957,7 @@
     "id": "zlFMVwBqCPXc"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/lightkurve_combining_multiple_quarters/lightkurve_combining_multiple_quarters.ipynb
+++ b/notebooks/Kepler/lightkurve_combining_multiple_quarters/lightkurve_combining_multiple_quarters.ipynb
@@ -450,7 +450,7 @@
     "id": "CNf3nI0trtA-"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/lightkurve_custom_aperture_photometry/lightkurve_custom_aperture_photometry.ipynb
+++ b/notebooks/Kepler/lightkurve_custom_aperture_photometry/lightkurve_custom_aperture_photometry.ipynb
@@ -732,7 +732,7 @@
     "id": "y1HbVfHwDVeN"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/Kepler/lightkurve_interactively_inspecting_TPFs_and_LCs/lightkurve_interactively_inspecting_TPFs_and_LCs.ipynb
+++ b/notebooks/Kepler/lightkurve_interactively_inspecting_TPFs_and_LCs/lightkurve_interactively_inspecting_TPFs_and_LCs.ipynb
@@ -408,7 +408,7 @@
     "id": "zFbaRDHeaxe4"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/lightkurve_searching_for_data/lightkurve_searching_for_data.ipynb
+++ b/notebooks/Kepler/lightkurve_searching_for_data/lightkurve_searching_for_data.ipynb
@@ -620,7 +620,7 @@
     "id": "UORqugNo89Zg"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n"
    ]
   }
  ],

--- a/notebooks/Kepler/measuring_a_rotation_period/measuring_a_rotation_period.ipynb
+++ b/notebooks/Kepler/measuring_a_rotation_period/measuring_a_rotation_period.ipynb
@@ -391,7 +391,7 @@
     "id": "8WhoNdhY7gt_"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/Kepler/plotting_catalog_over_FFI/plotting_catalog_over_FFI.ipynb
+++ b/notebooks/Kepler/plotting_catalog_over_FFI/plotting_catalog_over_FFI.ipynb
@@ -545,7 +545,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/Kepler/plotting_dvts/plotting_dvts.ipynb
+++ b/notebooks/Kepler/plotting_dvts/plotting_dvts.ipynb
@@ -216,7 +216,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/Kepler/plotting_images_from_tpf/plotting_images_from_tpf.ipynb
+++ b/notebooks/Kepler/plotting_images_from_tpf/plotting_images_from_tpf.ipynb
@@ -602,7 +602,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/Kepler/plotting_lightcurves/plotting_lightcurves.ipynb
+++ b/notebooks/Kepler/plotting_lightcurves/plotting_lightcurves.ipynb
@@ -448,7 +448,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/Kepler/verifying_the_location_of_a_signal/verifying_the_location_of_a_signal.ipynb
+++ b/notebooks/Kepler/verifying_the_location_of_a_signal/verifying_the_location_of_a_signal.ipynb
@@ -594,7 +594,7 @@
     "id": "y1HbVfHwDVeN"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/Kepler/visualizing_periodic_signals_using_a_river_plot/visualizing_periodic_signals_using_a_river_plot.ipynb
+++ b/notebooks/Kepler/visualizing_periodic_signals_using_a_river_plot/visualizing_periodic_signals_using_a_river_plot.ipynb
@@ -279,7 +279,7 @@
     "id": "9-YnV2qVoTMk"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/PanSTARRS/PS1_image/PS1_image.ipynb
+++ b/notebooks/PanSTARRS/PS1_image/PS1_image.ipynb
@@ -350,7 +350,7 @@
     "For support, please contact the Archive HelpDesk at archive@stsci.edu.\n",
     "\n",
     "***\n",
-    " <img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n",
+    " <img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n",
     "\n",
     "[Return to top of page](#top)"
    ]

--- a/notebooks/TESS/asteroid_rotation/asteroid_rotation.ipynb
+++ b/notebooks/TESS/asteroid_rotation/asteroid_rotation.ipynb
@@ -804,7 +804,7 @@
     "**Last Updated:**  Apr 2023\n",
     "***\n",
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/asteroid_rotation/asteroid_rotation_soutions.ipynb
+++ b/notebooks/TESS/asteroid_rotation/asteroid_rotation_soutions.ipynb
@@ -307,7 +307,7 @@
     "***\n",
     "[Back to top](#Top)\n",
     "\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_astroquery_dv/beginner_astroquery_dv.ipynb
+++ b/notebooks/TESS/beginner_astroquery_dv/beginner_astroquery_dv.ipynb
@@ -304,7 +304,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_how_to_use_dvt/beginner_how_to_use_dvt.ipynb
+++ b/notebooks/TESS/beginner_how_to_use_dvt/beginner_how_to_use_dvt.ipynb
@@ -215,7 +215,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_how_to_use_ffi/beginner_how_to_use_ffi.ipynb
+++ b/notebooks/TESS/beginner_how_to_use_ffi/beginner_how_to_use_ffi.ipynb
@@ -193,7 +193,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_how_to_use_lc/beginner_how_to_use_lc.ipynb
+++ b/notebooks/TESS/beginner_how_to_use_lc/beginner_how_to_use_lc.ipynb
@@ -307,7 +307,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_how_to_use_tp/beginner_how_to_use_tp.ipynb
+++ b/notebooks/TESS/beginner_how_to_use_tp/beginner_how_to_use_tp.ipynb
@@ -334,7 +334,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_tess_exomast/beginner_tess_exomast.ipynb
+++ b/notebooks/TESS/beginner_tess_exomast/beginner_tess_exomast.ipynb
@@ -307,7 +307,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#top_page)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_tess_tap_search/beginner_tess_tap_search.ipynb
+++ b/notebooks/TESS/beginner_tess_tap_search/beginner_tess_tap_search.ipynb
@@ -363,7 +363,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_tic_search_hd209458/beginner_tic_search_hd209458.ipynb
+++ b/notebooks/TESS/beginner_tic_search_hd209458/beginner_tic_search_hd209458.ipynb
@@ -165,7 +165,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/beginner_tour_lc_tp/beginner_tour_lc_tp.ipynb
+++ b/notebooks/TESS/beginner_tour_lc_tp/beginner_tour_lc_tp.ipynb
@@ -887,7 +887,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/interm_gi_query/interm_gi_query.ipynb
+++ b/notebooks/TESS/interm_gi_query/interm_gi_query.ipynb
@@ -226,7 +226,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   },
   {

--- a/notebooks/TESS/interm_tasoc_lc/interm_tasoc_lc.ipynb
+++ b/notebooks/TESS/interm_tasoc_lc/interm_tasoc_lc.ipynb
@@ -870,7 +870,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/interm_tess_prf_retrieve/interm_tess_prf_retrieve.ipynb
+++ b/notebooks/TESS/interm_tess_prf_retrieve/interm_tess_prf_retrieve.ipynb
@@ -848,7 +848,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   },
   {

--- a/notebooks/TESS/interm_tesscut_dss_overlay/interm_tesscut_dss_overlay.ipynb
+++ b/notebooks/TESS/interm_tesscut_dss_overlay/interm_tesscut_dss_overlay.ipynb
@@ -586,7 +586,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/interm_tesscut_requests/interm_tesscut_requests.ipynb
+++ b/notebooks/TESS/interm_tesscut_requests/interm_tesscut_requests.ipynb
@@ -352,7 +352,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#title_ID)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/making_tess_cubes_and_cutouts/making_tess_cubes_and_cutouts.ipynb
+++ b/notebooks/TESS/making_tess_cubes_and_cutouts/making_tess_cubes_and_cutouts.ipynb
@@ -726,7 +726,7 @@
     "**Last Updated:** Mar 2023 <br>\n",
     "***\n",
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/TESS/removing_scattered_light_using_regression/removing_scattered_light_using_regression.ipynb
+++ b/notebooks/TESS/removing_scattered_light_using_regression/removing_scattered_light_using_regression.ipynb
@@ -834,7 +834,7 @@
     "id": "ZhdRVU3B_Zn2"
    },
    "source": [
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
   }
  ],

--- a/notebooks/multi_mission/beginner_search/beginner_search.ipynb
+++ b/notebooks/multi_mission/beginner_search/beginner_search.ipynb
@@ -494,7 +494,7 @@
    "metadata": {},
    "source": [
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/multi_mission/beginner_zcut/beginner_zcut.ipynb
+++ b/notebooks/multi_mission/beginner_zcut/beginner_zcut.ipynb
@@ -288,7 +288,7 @@
     "**Last Updated:** July 2022<br>\n",
     "**Next Review:** Jan 2023\n",
     "\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> \n",
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"STScI logo\" width=\"200px\"/> \n",
     "\n",
     "[Top of Page](#Beginner:-Zcut-using-Astrocut-and-Astroquery-Tutorial)"
    ]

--- a/notebooks/multi_mission/display_footprints/display_footprints.ipynb
+++ b/notebooks/multi_mission/display_footprints/display_footprints.ipynb
@@ -402,7 +402,7 @@
     "\n",
     "***\n",
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],

--- a/notebooks/multi_mission/historic_quasar_observations/historic_quasar_observations.ipynb
+++ b/notebooks/multi_mission/historic_quasar_observations/historic_quasar_observations.ipynb
@@ -587,7 +587,7 @@
     "If you have questions, comments, or other feedback, please contact the Archive HelpDesk at archive@stsci.edu.\n",
     "\n",
     "***\n",
-    " <img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n",
+    " <img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>\n",
     "\n",
     "[Return to top of page](#Historical-Quasar-Observations)"
    ]

--- a/notebooks/multi_mission/large_downloads/large_downloads.ipynb
+++ b/notebooks/multi_mission/large_downloads/large_downloads.ipynb
@@ -185,7 +185,7 @@
     "**Next Review Date:** Feb 2023\n",
     "***\n",
     "[Top of Page](#top)\n",
-    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/hst_notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
   }
  ],


### PR DESCRIPTION
Replaced broken STScI logo links found in many MAST notebooks with a new link that works.  The old link was:

https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png

Only one component of the path changes in the new link:

...spacetelescope/hst_notebooks/master/...

The only changed line in each notebook is the one containing this link.