### PR TITLE
Adding onto MAST visualizations notebook with filtering exercises and examples for user

### DIFF
--- a/notebooks/Visualizations/mast_sky/mast_sky.ipynb
+++ b/notebooks/Visualizations/mast_sky/mast_sky.ipynb
@@ -14,7 +14,7 @@
     "- Create a visualization of the MAST archive and the data it contains\n",
     "- Learn about some of the different missions with data hosted at MAST and what their footprints look like\n",
     "- Understand how to convert between celestial coordinates (RA, Dec) and other coordinate systems using astropy\n",
-    "- Create your own wallpaper image of MAST to use as a Desktop background\n",
+    "- Create your own wallpaper image of MAST to use as a Desktop background!\n",
     "- Learn how to filter and visualize observations by different criteria"
    ]
   },
@@ -74,13 +74,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:15.777848Z",
-     "iopub.status.busy": "2026-07-14T15:34:15.776968Z",
-     "iopub.status.idle": "2026-07-14T15:34:16.647343Z",
-     "shell.execute_reply": "2026-07-14T15:34:16.646865Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:15.777784Z"
-    },
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -112,15 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:21.455796Z",
-     "iopub.status.busy": "2026-07-14T15:34:21.454905Z",
-     "iopub.status.idle": "2026-07-14T15:34:21.474263Z",
-     "shell.execute_reply": "2026-07-14T15:34:21.471647Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:21.455740Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Update Plotting Parameters\n",
@@ -176,13 +161,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:23.528993Z",
-     "iopub.status.busy": "2026-07-14T15:34:23.528137Z",
-     "iopub.status.idle": "2026-07-14T15:34:23.545708Z",
-     "shell.execute_reply": "2026-07-14T15:34:23.543635Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:23.528939Z"
-    },
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -211,15 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:24.777299Z",
-     "iopub.status.busy": "2026-07-14T15:34:24.776337Z",
-     "iopub.status.idle": "2026-07-14T15:34:24.800628Z",
-     "shell.execute_reply": "2026-07-14T15:34:24.799773Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:24.777238Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ra_coords = mast_data[\"ra\"]\n",
@@ -237,15 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:25.728628Z",
-     "iopub.status.busy": "2026-07-14T15:34:25.727827Z",
-     "iopub.status.idle": "2026-07-14T15:34:25.745481Z",
-     "shell.execute_reply": "2026-07-14T15:34:25.743823Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:25.728577Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(f\"Shape of observation_counts: {observation_counts.shape}\")\n",
@@ -271,15 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:26.761777Z",
-     "iopub.status.busy": "2026-07-14T15:34:26.761016Z",
-     "iopub.status.idle": "2026-07-14T15:34:27.399271Z",
-     "shell.execute_reply": "2026-07-14T15:34:27.398888Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:26.761726Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -338,15 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:28.288557Z",
-     "iopub.status.busy": "2026-07-14T15:34:28.287890Z",
-     "iopub.status.idle": "2026-07-14T15:34:28.310761Z",
-     "shell.execute_reply": "2026-07-14T15:34:28.309659Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:28.288484Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(\"Maxmimum Observations at a Single Location\")\n",
@@ -371,15 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:29.217591Z",
-     "iopub.status.busy": "2026-07-14T15:34:29.216827Z",
-     "iopub.status.idle": "2026-07-14T15:34:30.473665Z",
-     "shell.execute_reply": "2026-07-14T15:34:30.466588Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:29.217541Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Retrieve coordinates of the Andromeda Galaxy\n",
@@ -399,15 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:55.744714Z",
-     "iopub.status.busy": "2026-07-14T15:34:55.743816Z",
-     "iopub.status.idle": "2026-07-14T15:34:56.493010Z",
-     "shell.execute_reply": "2026-07-14T15:34:56.487046Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:55.744628Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Retrieve coordinates of the center of the MW\n",
@@ -424,15 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:56.970372Z",
-     "iopub.status.busy": "2026-07-14T15:34:56.969574Z",
-     "iopub.status.idle": "2026-07-14T15:34:57.610987Z",
-     "shell.execute_reply": "2026-07-14T15:34:57.605775Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:56.970318Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Retrieve coordinates of your favorite object!\n",
@@ -457,15 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:58.583970Z",
-     "iopub.status.busy": "2026-07-14T15:34:58.583222Z",
-     "iopub.status.idle": "2026-07-14T15:34:58.611940Z",
-     "shell.execute_reply": "2026-07-14T15:34:58.611206Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:58.583917Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def add_annotations():\n",
@@ -693,15 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:34:59.046865Z",
-     "iopub.status.busy": "2026-07-14T15:34:59.045937Z",
-     "iopub.status.idle": "2026-07-14T15:35:11.576266Z",
-     "shell.execute_reply": "2026-07-14T15:35:11.575665Z",
-     "shell.execute_reply.started": "2026-07-14T15:34:59.046807Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -787,15 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:11.576743Z",
-     "iopub.status.busy": "2026-07-14T15:35:11.576649Z",
-     "iopub.status.idle": "2026-07-14T15:35:11.849422Z",
-     "shell.execute_reply": "2026-07-14T15:35:11.848995Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:11.576735Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Convert from the grid edges into a meshgrid\n",
@@ -820,15 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:11.849794Z",
-     "iopub.status.busy": "2026-07-14T15:35:11.849715Z",
-     "iopub.status.idle": "2026-07-14T15:35:23.606744Z",
-     "shell.execute_reply": "2026-07-14T15:35:23.606211Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:11.849786Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -889,15 +779,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:23.607215Z",
-     "iopub.status.busy": "2026-07-14T15:35:23.607136Z",
-     "iopub.status.idle": "2026-07-14T15:35:23.844312Z",
-     "shell.execute_reply": "2026-07-14T15:35:23.843905Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:23.607208Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Convert from the grid edges into a meshgrid\n",
@@ -915,15 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:23.844714Z",
-     "iopub.status.busy": "2026-07-14T15:35:23.844623Z",
-     "iopub.status.idle": "2026-07-14T15:35:35.556481Z",
-     "shell.execute_reply": "2026-07-14T15:35:35.555977Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:23.844706Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -975,15 +849,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:35.556881Z",
-     "iopub.status.busy": "2026-07-14T15:35:35.556793Z",
-     "iopub.status.idle": "2026-07-14T15:35:38.981273Z",
-     "shell.execute_reply": "2026-07-14T15:35:38.980887Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:35.556873Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot - 16:9 aspect ratio for wallpaper\n",
@@ -1053,15 +919,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:38.981626Z",
-     "iopub.status.busy": "2026-07-14T15:35:38.981540Z",
-     "iopub.status.idle": "2026-07-14T15:35:38.983600Z",
-     "shell.execute_reply": "2026-07-14T15:35:38.983007Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:38.981618Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "colormap = \"magma\""
@@ -1070,15 +928,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:46.715626Z",
-     "iopub.status.busy": "2026-07-14T15:35:46.714378Z",
-     "iopub.status.idle": "2026-07-14T15:35:49.375278Z",
-     "shell.execute_reply": "2026-07-14T15:35:49.374791Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:46.715566Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot - 16:9 aspect ratio for wallpaper\n",
@@ -1148,15 +998,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-30T13:35:39.702232Z",
-     "iopub.status.busy": "2026-06-30T13:35:39.701444Z",
-     "iopub.status.idle": "2026-06-30T13:35:39.712198Z",
-     "shell.execute_reply": "2026-06-30T13:35:39.708131Z",
-     "shell.execute_reply.started": "2026-06-30T13:35:39.702177Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Filtering by Mission"
    ]
@@ -1171,15 +1013,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:49.536202Z",
-     "iopub.status.busy": "2026-07-14T15:35:49.535901Z",
-     "iopub.status.idle": "2026-07-14T15:35:49.541523Z",
-     "shell.execute_reply": "2026-07-14T15:35:49.540968Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:49.536180Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Function to Query the Data\n",
@@ -1225,13 +1059,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:35:53.333018Z",
-     "iopub.status.busy": "2026-07-14T15:35:53.332151Z",
-     "iopub.status.idle": "2026-07-14T15:43:38.679316Z",
-     "shell.execute_reply": "2026-07-14T15:43:38.678815Z",
-     "shell.execute_reply.started": "2026-07-14T15:35:53.332977Z"
-    },
     "jupyter": {
      "outputs_hidden": true
     }
@@ -1252,15 +1079,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:46:52.715138Z",
-     "iopub.status.busy": "2026-07-14T15:46:52.714338Z",
-     "iopub.status.idle": "2026-07-14T15:46:53.025141Z",
-     "shell.execute_reply": "2026-07-14T15:46:53.024692Z",
-     "shell.execute_reply.started": "2026-07-14T15:46:52.715088Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Converts coordinates into array\n",
@@ -1284,15 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:46:54.916568Z",
-     "iopub.status.busy": "2026-07-14T15:46:54.915606Z",
-     "iopub.status.idle": "2026-07-14T15:46:55.587482Z",
-     "shell.execute_reply": "2026-07-14T15:46:55.587055Z",
-     "shell.execute_reply.started": "2026-07-14T15:46:54.916513Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -1351,15 +1162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:47:01.647939Z",
-     "iopub.status.busy": "2026-07-14T15:47:01.647118Z",
-     "iopub.status.idle": "2026-07-14T15:47:01.659026Z",
-     "shell.execute_reply": "2026-07-14T15:47:01.657102Z",
-     "shell.execute_reply.started": "2026-07-14T15:47:01.647887Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# List the available missions"
@@ -1368,15 +1171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:47:03.277664Z",
-     "iopub.status.busy": "2026-07-14T15:47:03.276720Z",
-     "iopub.status.idle": "2026-07-14T15:47:03.287232Z",
-     "shell.execute_reply": "2026-07-14T15:47:03.284629Z",
-     "shell.execute_reply.started": "2026-07-14T15:47:03.277604Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Query data"
@@ -1385,15 +1180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:47:03.623376Z",
-     "iopub.status.busy": "2026-07-14T15:47:03.622552Z",
-     "iopub.status.idle": "2026-07-14T15:47:03.634352Z",
-     "shell.execute_reply": "2026-07-14T15:47:03.631895Z",
-     "shell.execute_reply.started": "2026-07-14T15:47:03.623315Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Convert into array"
@@ -1402,15 +1189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:47:03.958675Z",
-     "iopub.status.busy": "2026-07-14T15:47:03.957601Z",
-     "iopub.status.idle": "2026-07-14T15:47:03.968069Z",
-     "shell.execute_reply": "2026-07-14T15:47:03.964835Z",
-     "shell.execute_reply.started": "2026-07-14T15:47:03.958462Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot"
@@ -1433,15 +1212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:47:06.595679Z",
-     "iopub.status.busy": "2026-07-14T15:47:06.594893Z",
-     "iopub.status.idle": "2026-07-14T15:47:06.642952Z",
-     "shell.execute_reply": "2026-07-14T15:47:06.641712Z",
-     "shell.execute_reply.started": "2026-07-14T15:47:06.595622Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "meta_table = Observations.get_metadata(\"observations\") # Get a list of all the columns\n",
@@ -1458,15 +1229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:47:09.453339Z",
-     "iopub.status.busy": "2026-07-14T15:47:09.452517Z",
-     "iopub.status.idle": "2026-07-14T15:47:09.467484Z",
-     "shell.execute_reply": "2026-07-14T15:47:09.464759Z",
-     "shell.execute_reply.started": "2026-07-14T15:47:09.453289Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Function to Query the Data\n",
@@ -1505,13 +1268,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:47:11.593286Z",
-     "iopub.status.busy": "2026-07-14T15:47:11.592447Z",
-     "iopub.status.idle": "2026-07-14T15:48:41.398787Z",
-     "shell.execute_reply": "2026-07-14T15:48:41.398365Z",
-     "shell.execute_reply.started": "2026-07-14T15:47:11.593238Z"
-    },
     "jupyter": {
      "outputs_hidden": true
     }
@@ -1524,15 +1280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:51:42.731445Z",
-     "iopub.status.busy": "2026-07-14T15:51:42.730603Z",
-     "iopub.status.idle": "2026-07-14T15:51:43.203586Z",
-     "shell.execute_reply": "2026-07-14T15:51:43.203127Z",
-     "shell.execute_reply.started": "2026-07-14T15:51:42.731396Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Converts coordinates into array\n",
@@ -1582,15 +1330,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-06T16:05:38.382627Z",
-     "iopub.status.busy": "2026-07-06T16:05:38.381853Z",
-     "iopub.status.idle": "2026-07-06T16:05:38.393151Z",
-     "shell.execute_reply": "2026-07-06T16:05:38.391236Z",
-     "shell.execute_reply.started": "2026-07-06T16:05:38.382584Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "Now, we know how to filter based on different columns! For the next exercise, we can try filtering based on **instruments** instead."
    ]
@@ -1598,15 +1338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:51:46.405515Z",
-     "iopub.status.busy": "2026-07-14T15:51:46.404543Z",
-     "iopub.status.idle": "2026-07-14T15:51:46.415671Z",
-     "shell.execute_reply": "2026-07-14T15:51:46.413980Z",
-     "shell.execute_reply.started": "2026-07-14T15:51:46.405454Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Write function here to filter by instruments"
@@ -1615,15 +1347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:51:46.724516Z",
-     "iopub.status.busy": "2026-07-14T15:51:46.723664Z",
-     "iopub.status.idle": "2026-07-14T15:51:46.735214Z",
-     "shell.execute_reply": "2026-07-14T15:51:46.732204Z",
-     "shell.execute_reply.started": "2026-07-14T15:51:46.724458Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Convert into a 2D array "
@@ -1632,15 +1356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:51:47.500143Z",
-     "iopub.status.busy": "2026-07-14T15:51:47.499379Z",
-     "iopub.status.idle": "2026-07-14T15:51:47.509393Z",
-     "shell.execute_reply": "2026-07-14T15:51:47.506106Z",
-     "shell.execute_reply.started": "2026-07-14T15:51:47.500088Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot"
@@ -1677,15 +1393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:51:50.037025Z",
-     "iopub.status.busy": "2026-07-14T15:51:50.036164Z",
-     "iopub.status.idle": "2026-07-14T15:51:50.542293Z",
-     "shell.execute_reply": "2026-07-14T15:51:50.541023Z",
-     "shell.execute_reply.started": "2026-07-14T15:51:50.036971Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(Observations.list_missions())"
@@ -1694,15 +1402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:51:51.425153Z",
-     "iopub.status.busy": "2026-07-14T15:51:51.424401Z",
-     "iopub.status.idle": "2026-07-14T15:57:48.978815Z",
-     "shell.execute_reply": "2026-07-14T15:57:48.978397Z",
-     "shell.execute_reply.started": "2026-07-14T15:51:51.425110Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "filter_ra_coords, filter_dec_coords = query_mission_data('HST') # Run HST as the queried mission\n",
@@ -1723,15 +1423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:58:23.589296Z",
-     "iopub.status.busy": "2026-07-14T15:58:23.588442Z",
-     "iopub.status.idle": "2026-07-14T15:58:24.033995Z",
-     "shell.execute_reply": "2026-07-14T15:58:24.033404Z",
-     "shell.execute_reply.started": "2026-07-14T15:58:23.589227Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -1778,15 +1470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:58:31.926606Z",
-     "iopub.status.busy": "2026-07-14T15:58:31.925836Z",
-     "iopub.status.idle": "2026-07-14T15:58:31.941511Z",
-     "shell.execute_reply": "2026-07-14T15:58:31.938365Z",
-     "shell.execute_reply.started": "2026-07-14T15:58:31.926556Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Function to Query the Data\n",
@@ -1818,15 +1502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:59:13.141341Z",
-     "iopub.status.busy": "2026-07-14T15:59:13.140546Z",
-     "iopub.status.idle": "2026-07-14T16:00:31.043197Z",
-     "shell.execute_reply": "2026-07-14T16:00:31.042771Z",
-     "shell.execute_reply.started": "2026-07-14T15:59:13.141294Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Call function\n",
@@ -1846,15 +1522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T16:03:35.151105Z",
-     "iopub.status.busy": "2026-07-14T16:03:35.150306Z",
-     "iopub.status.idle": "2026-07-14T16:03:35.586251Z",
-     "shell.execute_reply": "2026-07-14T16:03:35.585818Z",
-     "shell.execute_reply.started": "2026-07-14T16:03:35.151052Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -1893,15 +1561,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T15:30:11.112571Z",
-     "iopub.status.busy": "2026-07-14T15:30:11.111804Z",
-     "iopub.status.idle": "2026-07-14T15:30:11.126352Z",
-     "shell.execute_reply": "2026-07-14T15:30:11.124489Z",
-     "shell.execute_reply.started": "2026-07-14T15:30:11.112516Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "This is what it would look like if we filtered based on the **Kepler** mission!"
    ]
@@ -1909,15 +1569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T17:00:15.993315Z",
-     "iopub.status.busy": "2026-07-14T17:00:15.992730Z",
-     "iopub.status.idle": "2026-07-14T17:01:22.530575Z",
-     "shell.execute_reply": "2026-07-14T17:01:22.529940Z",
-     "shell.execute_reply.started": "2026-07-14T17:00:15.993282Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "filter_ra_coords, filter_dec_coords = query_mission_data('Kepler')\n",
@@ -1934,15 +1586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T17:01:22.531105Z",
-     "iopub.status.busy": "2026-07-14T17:01:22.531016Z",
-     "iopub.status.idle": "2026-07-14T17:01:22.903908Z",
-     "shell.execute_reply": "2026-07-14T17:01:22.903398Z",
-     "shell.execute_reply.started": "2026-07-14T17:01:22.531097Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -1983,13 +1627,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T17:01:22.904216Z",
-     "iopub.status.busy": "2026-07-14T17:01:22.904141Z",
-     "iopub.status.idle": "2026-07-14T17:03:59.131940Z",
-     "shell.execute_reply": "2026-07-14T17:03:59.131505Z",
-     "shell.execute_reply.started": "2026-07-14T17:01:22.904209Z"
-    },
     "jupyter": {
      "outputs_hidden": true
     }
@@ -2010,15 +1647,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-14T17:04:04.489489Z",
-     "iopub.status.busy": "2026-07-14T17:04:04.488845Z",
-     "iopub.status.idle": "2026-07-14T17:04:04.909098Z",
-     "shell.execute_reply": "2026-07-14T17:04:04.908688Z",
-     "shell.execute_reply.started": "2026-07-14T17:04:04.489448Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -2095,12 +1724,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "SQL",
-   "language": "sql",
-   "name": "sql-notebook"
+   "display_name": "Python (mywork)",
+   "language": "python",
+   "name": "mywork"
   },
   "language_info": {
-   "name": "sql"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/Visualizations/mast_sky/mast_sky.ipynb
+++ b/notebooks/Visualizations/mast_sky/mast_sky.ipynb
@@ -14,7 +14,8 @@
     "- Create a visualization of the MAST archive and the data it contains\n",
     "- Learn about some of the different missions with data hosted at MAST and what their footprints look like\n",
     "- Understand how to convert between celestial coordinates (RA, Dec) and other coordinate systems using astropy\n",
-    "- Create your own wallpaper image of MAST to use as a Desktop background!\n"
+    "- Create your own wallpaper image of MAST to use as a Desktop background\n",
+    "- Learn how to filter and visualize observations by different criteria"
    ]
   },
   {
@@ -35,6 +36,8 @@
     "    * [Ecliptic Coordinates](#Ecliptic-Coordinates)\n",
     "    * [Galactic Coordinates](#Galactic-Coordinates)\n",
     "* [MAST Wallpaper Image](#MAST-Wallpaper-Image)\n",
+    "* [Filtering Exercises](#Filtering-Exercises)\n",
+    "* [Solutions to Exercises](#Solutions-to-Exercises)\n",
     "* [Additional Resources](#Additional-Resources)\n",
     "  * [Citations](#Citations)\n",
     "  * [About This Notebook](#About-this-Notebook)\n",
@@ -71,6 +74,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:15.777848Z",
+     "iopub.status.busy": "2026-07-14T15:34:15.776968Z",
+     "iopub.status.idle": "2026-07-14T15:34:16.647343Z",
+     "shell.execute_reply": "2026-07-14T15:34:16.646865Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:15.777784Z"
+    },
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -102,7 +112,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:21.455796Z",
+     "iopub.status.busy": "2026-07-14T15:34:21.454905Z",
+     "iopub.status.idle": "2026-07-14T15:34:21.474263Z",
+     "shell.execute_reply": "2026-07-14T15:34:21.471647Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:21.455740Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Update Plotting Parameters\n",
@@ -151,13 +169,20 @@
     }
    },
    "source": [
-    "The file provided with this notebook, `mast_obscounts.npz`, contains the observation counts in MAST for every coordinate in the sky. Let's open the file and view its contents:"
+    "The file provided with this notebook, `mast_obscounts.npz`, contains the observation counts in MAST for every coordinate in the sky. Please make sure to download it from the repository before you begin. Let's open the file and view its contents:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:23.528993Z",
+     "iopub.status.busy": "2026-07-14T15:34:23.528137Z",
+     "iopub.status.idle": "2026-07-14T15:34:23.545708Z",
+     "shell.execute_reply": "2026-07-14T15:34:23.543635Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:23.528939Z"
+    },
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -186,7 +211,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:24.777299Z",
+     "iopub.status.busy": "2026-07-14T15:34:24.776337Z",
+     "iopub.status.idle": "2026-07-14T15:34:24.800628Z",
+     "shell.execute_reply": "2026-07-14T15:34:24.799773Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:24.777238Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ra_coords = mast_data[\"ra\"]\n",
@@ -204,7 +237,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:25.728628Z",
+     "iopub.status.busy": "2026-07-14T15:34:25.727827Z",
+     "iopub.status.idle": "2026-07-14T15:34:25.745481Z",
+     "shell.execute_reply": "2026-07-14T15:34:25.743823Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:25.728577Z"
+    }
+   },
    "outputs": [],
    "source": [
     "print(f\"Shape of observation_counts: {observation_counts.shape}\")\n",
@@ -230,7 +271,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:26.761777Z",
+     "iopub.status.busy": "2026-07-14T15:34:26.761016Z",
+     "iopub.status.idle": "2026-07-14T15:34:27.399271Z",
+     "shell.execute_reply": "2026-07-14T15:34:27.398888Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:26.761726Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -242,7 +291,7 @@
     "# Define a custom color map\n",
     "# This will create a gradient from black to blue to white!\n",
     "colormap = LinearSegmentedColormap.from_list(\n",
-    "    \"\", [\"black\", \"midnightblue\", \"#1a619f\", \"deepskyblue\", \"white\"]\n",
+    "    \"\", [\"black\", \"midnightblue\", \"#1a619f\", \"skyblue\", \"white\"]\n",
     ")\n",
     "\n",
     "# Plot the data\n",
@@ -289,7 +338,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:28.288557Z",
+     "iopub.status.busy": "2026-07-14T15:34:28.287890Z",
+     "iopub.status.idle": "2026-07-14T15:34:28.310761Z",
+     "shell.execute_reply": "2026-07-14T15:34:28.309659Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:28.288484Z"
+    }
+   },
    "outputs": [],
    "source": [
     "print(\"Maxmimum Observations at a Single Location\")\n",
@@ -314,7 +371,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:29.217591Z",
+     "iopub.status.busy": "2026-07-14T15:34:29.216827Z",
+     "iopub.status.idle": "2026-07-14T15:34:30.473665Z",
+     "shell.execute_reply": "2026-07-14T15:34:30.466588Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:29.217541Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Retrieve coordinates of the Andromeda Galaxy\n",
@@ -334,7 +399,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:55.744714Z",
+     "iopub.status.busy": "2026-07-14T15:34:55.743816Z",
+     "iopub.status.idle": "2026-07-14T15:34:56.493010Z",
+     "shell.execute_reply": "2026-07-14T15:34:56.487046Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:55.744628Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Retrieve coordinates of the center of the MW\n",
@@ -351,12 +424,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:56.970372Z",
+     "iopub.status.busy": "2026-07-14T15:34:56.969574Z",
+     "iopub.status.idle": "2026-07-14T15:34:57.610987Z",
+     "shell.execute_reply": "2026-07-14T15:34:57.605775Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:56.970318Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Retrieve coordinates of your favorite object!\n",
-    "my_favorite_object = \"Crab Nebula\"\n",
+    "my_favorite_object = \"Sirius\"\n",
     "Observations.resolve_object(my_favorite_object)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Annotating Plots"
    ]
   },
   {
@@ -369,7 +457,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:58.583970Z",
+     "iopub.status.busy": "2026-07-14T15:34:58.583222Z",
+     "iopub.status.idle": "2026-07-14T15:34:58.611940Z",
+     "shell.execute_reply": "2026-07-14T15:34:58.611206Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:58.583917Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def add_annotations():\n",
@@ -597,7 +693,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:34:59.046865Z",
+     "iopub.status.busy": "2026-07-14T15:34:59.045937Z",
+     "iopub.status.idle": "2026-07-14T15:35:11.576266Z",
+     "shell.execute_reply": "2026-07-14T15:35:11.575665Z",
+     "shell.execute_reply.started": "2026-07-14T15:34:59.046807Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -683,7 +787,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:11.576743Z",
+     "iopub.status.busy": "2026-07-14T15:35:11.576649Z",
+     "iopub.status.idle": "2026-07-14T15:35:11.849422Z",
+     "shell.execute_reply": "2026-07-14T15:35:11.848995Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:11.576735Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Convert from the grid edges into a meshgrid\n",
@@ -708,7 +820,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:11.849794Z",
+     "iopub.status.busy": "2026-07-14T15:35:11.849715Z",
+     "iopub.status.idle": "2026-07-14T15:35:23.606744Z",
+     "shell.execute_reply": "2026-07-14T15:35:23.606211Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:11.849786Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -769,7 +889,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:23.607215Z",
+     "iopub.status.busy": "2026-07-14T15:35:23.607136Z",
+     "iopub.status.idle": "2026-07-14T15:35:23.844312Z",
+     "shell.execute_reply": "2026-07-14T15:35:23.843905Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:23.607208Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Convert from the grid edges into a meshgrid\n",
@@ -787,7 +915,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:23.844714Z",
+     "iopub.status.busy": "2026-07-14T15:35:23.844623Z",
+     "iopub.status.idle": "2026-07-14T15:35:35.556481Z",
+     "shell.execute_reply": "2026-07-14T15:35:35.555977Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:23.844706Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Initiate plot\n",
@@ -833,13 +969,21 @@
    "source": [
     "## Wallpaper Image\n",
     "\n",
-    "Just for fun, let's make a pretty version of this plot to use as a Desktop Wallpaper, removing the axes and labels and focusing on the image."
+    "Just for fun, let's make a pretty version of this plot to use as a Desktop Wallpaper, removing the axes and labels and focusing on the image. Please download the image from the repository before you begin."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:35.556881Z",
+     "iopub.status.busy": "2026-07-14T15:35:35.556793Z",
+     "iopub.status.idle": "2026-07-14T15:35:38.981273Z",
+     "shell.execute_reply": "2026-07-14T15:35:38.980887Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:35.556873Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Initiate plot - 16:9 aspect ratio for wallpaper\n",
@@ -867,7 +1011,7 @@
     ")\n",
     "\n",
     "# Add MAST logo to corner\n",
-    "mast_logo = imread(\"imgs/MAST-Logo-Horizontal.png\")\n",
+    "mast_logo = imread(\"MAST-Logo-Horizontal.png\")\n",
     "# preserve aspect ratio so the logo isn't skewed\n",
     "mast_logo_ratio = mast_logo.shape[0] / mast_logo.shape[1] * (8 / 9)\n",
     "# Need extra 8/9 because the figure size is 16:9 but the pixel size is 16:8\n",
@@ -909,7 +1053,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:38.981626Z",
+     "iopub.status.busy": "2026-07-14T15:35:38.981540Z",
+     "iopub.status.idle": "2026-07-14T15:35:38.983600Z",
+     "shell.execute_reply": "2026-07-14T15:35:38.983007Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:38.981618Z"
+    }
+   },
    "outputs": [],
    "source": [
     "colormap = \"magma\""
@@ -918,7 +1070,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:46.715626Z",
+     "iopub.status.busy": "2026-07-14T15:35:46.714378Z",
+     "iopub.status.idle": "2026-07-14T15:35:49.375278Z",
+     "shell.execute_reply": "2026-07-14T15:35:49.374791Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:46.715566Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Initiate plot - 16:9 aspect ratio for wallpaper\n",
@@ -941,7 +1101,7 @@
     "\n",
     "\n",
     "# Add MAST logo to corner\n",
-    "mast_logo = imread(\"imgs/MAST-Logo-Horizontal.png\")\n",
+    "mast_logo = imread(\"MAST-Logo-Horizontal.png\")\n",
     "# preserve aspect ratio so the logo isn't skewed\n",
     "mast_logo_ratio = mast_logo.shape[0] / mast_logo.shape[1] * (8 / 9)\n",
     "# Need extra 8/9 because the figure size is 16:9 but the pixel size is 16:8\n",
@@ -968,6 +1128,931 @@
     "\n",
     "# Save file\n",
     "plt.savefig(\"mast_wallpaper2.png\", bbox_inches=\"tight\", dpi=300)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filtering Exercises"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the provided file, `mast_obscounts.npz`, only contains observation counts, right ascension, and declination coordinates, we can query more data through the `.Observations` class in Astroquery and filter based on other criteria, like mission, instrument, or filter. For more information on how to query data, feel free to check out the other MAST Jupyter Notebook tutorials."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T13:35:39.702232Z",
+     "iopub.status.busy": "2026-06-30T13:35:39.701444Z",
+     "iopub.status.idle": "2026-06-30T13:35:39.712198Z",
+     "shell.execute_reply": "2026-06-30T13:35:39.708131Z",
+     "shell.execute_reply.started": "2026-06-30T13:35:39.702177Z"
+    }
+   },
+   "source": [
+    "### Filtering by Mission"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the first exercise, we can query observations for different missions, starting with `TESS`, and then we can expand to other missions in the future. First, we need to query the RA and Dec. coords for the mission and bin those values into a 2D observation-count grid. Our first step is to start querying the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:49.536202Z",
+     "iopub.status.busy": "2026-07-14T15:35:49.535901Z",
+     "iopub.status.idle": "2026-07-14T15:35:49.541523Z",
+     "shell.execute_reply": "2026-07-14T15:35:49.540968Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:49.536180Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Function to Query the Data\n",
+    "def query_mission_data(mission): \n",
+    "    # Create empty list to store the coordinates\n",
+    "    ra_coords = []\n",
+    "    dec_coords = []\n",
+    "\n",
+    "    # Begin on page 1 in the portal\n",
+    "    page = 1\n",
+    "\n",
+    "    while True:\n",
+    "        # Query the data with the desired mission\n",
+    "        data = Observations.query_criteria(obs_collection = mission,\n",
+    "                                           pagesize = 1000,\n",
+    "                                           page = page)\n",
+    "        # Once there are no more rows to comb through, finish querying\n",
+    "        if len(data) == 0:\n",
+    "            print(\"Done\")\n",
+    "            break\n",
+    "        \n",
+    "        # Convert all coordinates from string to float\n",
+    "        ra_coords.extend(float(i) for i in data[\"s_ra\"])\n",
+    "        dec_coords.extend(float(i) for i in data[\"s_dec\"])\n",
+    "\n",
+    "        print(f\"Fetched page {page} with {len(data)} rows\")\n",
+    "\n",
+    "        page = page + 1\n",
+    "\n",
+    "    return ra_coords, dec_coords"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function to query data has been provided. We can now call the function with our desired mission. \n",
+    "\n",
+    "**NOTE: It might take a while to query the data.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:35:53.333018Z",
+     "iopub.status.busy": "2026-07-14T15:35:53.332151Z",
+     "iopub.status.idle": "2026-07-14T15:43:38.679316Z",
+     "shell.execute_reply": "2026-07-14T15:43:38.678815Z",
+     "shell.execute_reply.started": "2026-07-14T15:35:53.332977Z"
+    },
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Call the function with a specified mission\n",
+    "filter_ra_coords, filter_dec_coords = query_mission_data('TESS')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have queried our data, we must convert it into a 2D count grid. This is because `.imshow()`needs a 2D array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:46:52.715138Z",
+     "iopub.status.busy": "2026-07-14T15:46:52.714338Z",
+     "iopub.status.idle": "2026-07-14T15:46:53.025141Z",
+     "shell.execute_reply": "2026-07-14T15:46:53.024692Z",
+     "shell.execute_reply.started": "2026-07-14T15:46:52.715088Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Converts coordinates into array\n",
+    "filter_ra_coords = np.array(filter_ra_coords)\n",
+    "filter_dec_coords = np.array(filter_dec_coords)\n",
+    "\n",
+    "# Converts array into 2D count grid\n",
+    "filter_counts, ra_edges, dec_edges = np.histogram2d(filter_ra_coords, \n",
+    "                                                    filter_dec_coords, \n",
+    "                                                    bins = [2100, 1050], \n",
+    "                                                    range = [[0, 360], [-90, 90]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we hardcoded the map boundaries, we don't really need the edges, but it is a placeholder for the values that `np.histogram2d()` returns. Finally, we can plot the data following the same patten from above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:46:54.916568Z",
+     "iopub.status.busy": "2026-07-14T15:46:54.915606Z",
+     "iopub.status.idle": "2026-07-14T15:46:55.587482Z",
+     "shell.execute_reply": "2026-07-14T15:46:55.587055Z",
+     "shell.execute_reply.started": "2026-07-14T15:46:54.916513Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate plot\n",
+    "plt.figure(figsize=(12, 5))\n",
+    "\n",
+    "# Make background black\n",
+    "plt.axvspan(0, 360, color=\"k\", zorder=-1)\n",
+    "plt.style.use(\"default\")\n",
+    "\n",
+    "# Plot the data\n",
+    "im = plt.imshow(\n",
+    "    filter_counts.T,\n",
+    "    cmap=\"cool\",  # Set colormap\n",
+    "    norm=LogNorm(10, 1e3),  # Define limits of colormap\n",
+    "    extent=[0, 360, -90, 90],  # Set the limits of the data\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "\n",
+    "plt.colorbar(im, label=\"Observation Counts\", extend=\"both\")\n",
+    "\n",
+    "# Set axes limits\n",
+    "plt.xlim(0, 360)\n",
+    "plt.ylim(-90, 90)\n",
+    "\n",
+    "# Add labels to plot\n",
+    "plt.title(\"TESS Observations\")\n",
+    "plt.xlabel(\"Right Ascension (degrees)\")\n",
+    "plt.ylabel(\"Declination (degrees)\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Taking a look at the areas of the sky observed by TESS, as of July 2026, we can notice that there is a big empty patch around RA ≈ 250° and Dec ≈ 20°. This white region indicates that no TESS observations were returned for that area in the dataset. Since TESS observes the sky in discrete sectors, some regions have minimal coverage which appears as gaps in the observation count. However, TESS continues to observe the night sky, and as more data is uploaded into MAST, the empty patch in the sky will soon disappear. \n",
+    "\n",
+    "For the following exercise, try to find out what mission(s) have observations in that spot!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Exercise 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call the function with a new mission (ex: jwst), and plot generate MAST's view of the sky when only that mission is considered. You can find a list of available missions by running `print(Observations.list_missions())`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:47:01.647939Z",
+     "iopub.status.busy": "2026-07-14T15:47:01.647118Z",
+     "iopub.status.idle": "2026-07-14T15:47:01.659026Z",
+     "shell.execute_reply": "2026-07-14T15:47:01.657102Z",
+     "shell.execute_reply.started": "2026-07-14T15:47:01.647887Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# List the available missions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:47:03.277664Z",
+     "iopub.status.busy": "2026-07-14T15:47:03.276720Z",
+     "iopub.status.idle": "2026-07-14T15:47:03.287232Z",
+     "shell.execute_reply": "2026-07-14T15:47:03.284629Z",
+     "shell.execute_reply.started": "2026-07-14T15:47:03.277604Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Query data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:47:03.623376Z",
+     "iopub.status.busy": "2026-07-14T15:47:03.622552Z",
+     "iopub.status.idle": "2026-07-14T15:47:03.634352Z",
+     "shell.execute_reply": "2026-07-14T15:47:03.631895Z",
+     "shell.execute_reply.started": "2026-07-14T15:47:03.623315Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Convert into array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:47:03.958675Z",
+     "iopub.status.busy": "2026-07-14T15:47:03.957601Z",
+     "iopub.status.idle": "2026-07-14T15:47:03.968069Z",
+     "shell.execute_reply": "2026-07-14T15:47:03.964835Z",
+     "shell.execute_reply.started": "2026-07-14T15:47:03.958462Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filtering by Other Categories"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we know how to filter by mission. Let's check what other categories we can filter by. We can begin by taking a look at the names of the metadata columns. We can begin by looking at the first 20 names, and then cycle through the column names by using index slicing. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:47:06.595679Z",
+     "iopub.status.busy": "2026-07-14T15:47:06.594893Z",
+     "iopub.status.idle": "2026-07-14T15:47:06.642952Z",
+     "shell.execute_reply": "2026-07-14T15:47:06.641712Z",
+     "shell.execute_reply.started": "2026-07-14T15:47:06.595622Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "meta_table = Observations.get_metadata(\"observations\") # Get a list of all the columns\n",
+    "meta_table[:20] # List the first twenty results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's get observation counts of another column! Comparing the two functions from above and below, take notice how we now have swapped from `obs_collection` to `filters`. Anytime you want to query data from a different column, make sure you are swapping the column name!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:47:09.453339Z",
+     "iopub.status.busy": "2026-07-14T15:47:09.452517Z",
+     "iopub.status.idle": "2026-07-14T15:47:09.467484Z",
+     "shell.execute_reply": "2026-07-14T15:47:09.464759Z",
+     "shell.execute_reply.started": "2026-07-14T15:47:09.453289Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Function to Query the Data\n",
+    "def query_filter_data(value): \n",
+    "    ra_coords = []\n",
+    "    dec_coords = []\n",
+    "\n",
+    "    page = 1\n",
+    "\n",
+    "    while True:\n",
+    "        data = Observations.query_criteria(filters = value,\n",
+    "                                           pagesize = 1000,\n",
+    "                                           page = page)\n",
+    "        if len(data) == 0:\n",
+    "            print(\"Done\")\n",
+    "            break\n",
+    "\n",
+    "        ra_coords.extend(float(i) for i in data[\"s_ra\"])\n",
+    "        dec_coords.extend(float(i) for i in data[\"s_dec\"])\n",
+    "\n",
+    "        print(f\"Fetched page {page} with {len(data)} rows\")\n",
+    "\n",
+    "        page = page + 1\n",
+    "\n",
+    "    return ra_coords, dec_coords"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, call the function with a specific filter. To see a list of filters, you can check out the MAST advanced search in the portal and view the 780+ filters there are."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:47:11.593286Z",
+     "iopub.status.busy": "2026-07-14T15:47:11.592447Z",
+     "iopub.status.idle": "2026-07-14T15:48:41.398787Z",
+     "shell.execute_reply": "2026-07-14T15:48:41.398365Z",
+     "shell.execute_reply.started": "2026-07-14T15:47:11.593238Z"
+    },
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "filter_ra_coords, filter_dec_coords = query_filter_data('FUV') # In this example, I'm using the FUV filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:51:42.731445Z",
+     "iopub.status.busy": "2026-07-14T15:51:42.730603Z",
+     "iopub.status.idle": "2026-07-14T15:51:43.203586Z",
+     "shell.execute_reply": "2026-07-14T15:51:43.203127Z",
+     "shell.execute_reply.started": "2026-07-14T15:51:42.731396Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Converts coordinates into array\n",
+    "filter_ra_coords = np.array(filter_ra_coords)\n",
+    "filter_dec_coords = np.array(filter_dec_coords)\n",
+    "\n",
+    "# Converts array into 2D count grid\n",
+    "filter_counts, ra_edges, dec_edges = np.histogram2d(filter_ra_coords, \n",
+    "                                                    filter_dec_coords, \n",
+    "                                                    bins = [2100, 1050], \n",
+    "                                                    range = [[0, 360], [-90, 90]])\n",
+    "# Initiate plot\n",
+    "plt.figure(figsize=(12, 5))\n",
+    "\n",
+    "plt.axvspan(0, 360, color=\"k\", zorder=-1)\n",
+    "plt.style.use(\"default\")\n",
+    "\n",
+    "# Plot the data\n",
+    "im = plt.imshow(\n",
+    "    filter_counts.T,\n",
+    "    cmap=\"twilight\",  # Set colormap\n",
+    "    norm=LogNorm(10, 1e3),  # Define limits of colormap\n",
+    "    extent=[0, 360, -90, 90],  # Set the limits of the data\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "\n",
+    "plt.colorbar(im, label=\"Observation Counts\", extend=\"both\")\n",
+    "\n",
+    "# Set axes limits\n",
+    "plt.xlim(0, 360)\n",
+    "plt.ylim(-90, 90)\n",
+    "\n",
+    "# Add labels to plot\n",
+    "plt.title(\"Observation Map - FUV\")\n",
+    "plt.xlabel(\"Right Ascension (degrees)\")\n",
+    "plt.ylabel(\"Declination (degrees)\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Exercise 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-06T16:05:38.382627Z",
+     "iopub.status.busy": "2026-07-06T16:05:38.381853Z",
+     "iopub.status.idle": "2026-07-06T16:05:38.393151Z",
+     "shell.execute_reply": "2026-07-06T16:05:38.391236Z",
+     "shell.execute_reply.started": "2026-07-06T16:05:38.382584Z"
+    }
+   },
+   "source": [
+    "Now, we know how to filter based on different columns! For the next exercise, we can try filtering based on **instruments** instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:51:46.405515Z",
+     "iopub.status.busy": "2026-07-14T15:51:46.404543Z",
+     "iopub.status.idle": "2026-07-14T15:51:46.415671Z",
+     "shell.execute_reply": "2026-07-14T15:51:46.413980Z",
+     "shell.execute_reply.started": "2026-07-14T15:51:46.405454Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Write function here to filter by instruments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:51:46.724516Z",
+     "iopub.status.busy": "2026-07-14T15:51:46.723664Z",
+     "iopub.status.idle": "2026-07-14T15:51:46.735214Z",
+     "shell.execute_reply": "2026-07-14T15:51:46.732204Z",
+     "shell.execute_reply.started": "2026-07-14T15:51:46.724458Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Convert into a 2D array "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:51:47.500143Z",
+     "iopub.status.busy": "2026-07-14T15:51:47.499379Z",
+     "iopub.status.idle": "2026-07-14T15:51:47.509393Z",
+     "shell.execute_reply": "2026-07-14T15:51:47.506106Z",
+     "shell.execute_reply.started": "2026-07-14T15:51:47.500088Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot may not be as beautiful as the earlier plots, but that is okay. Our goal is to compare different ways we can filter observation counts!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Congrats on making it to the end of the notebook.** I've attached solutions to the exercises below. Feel free to create your own plots filtering based on different criteria! There are also a few more attached plots to different missions that you may find interesting!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Solutions to Exercises"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 1: Solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:51:50.037025Z",
+     "iopub.status.busy": "2026-07-14T15:51:50.036164Z",
+     "iopub.status.idle": "2026-07-14T15:51:50.542293Z",
+     "shell.execute_reply": "2026-07-14T15:51:50.541023Z",
+     "shell.execute_reply.started": "2026-07-14T15:51:50.036971Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(Observations.list_missions())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:51:51.425153Z",
+     "iopub.status.busy": "2026-07-14T15:51:51.424401Z",
+     "iopub.status.idle": "2026-07-14T15:57:48.978815Z",
+     "shell.execute_reply": "2026-07-14T15:57:48.978397Z",
+     "shell.execute_reply.started": "2026-07-14T15:51:51.425110Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "filter_ra_coords, filter_dec_coords = query_mission_data('HST') # Run HST as the queried mission\n",
+    "\n",
+    "# Note: HLSP and SPITZER_SHA do not run properly/take too long, I reccommend not querying those results.\n",
+    "\n",
+    "# Convert results into array\n",
+    "filter_ra_coords = np.array(filter_ra_coords)\n",
+    "filter_dec_coords = np.array(filter_dec_coords)\n",
+    "\n",
+    "# Convert into 2D grid count\n",
+    "filter_counts, ra_edges, dec_edges = np.histogram2d(filter_ra_coords, \n",
+    "                                                    filter_dec_coords, \n",
+    "                                                    bins = [2100, 1050], \n",
+    "                                                    range = [[0, 360], [-90, 90]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:58:23.589296Z",
+     "iopub.status.busy": "2026-07-14T15:58:23.588442Z",
+     "iopub.status.idle": "2026-07-14T15:58:24.033995Z",
+     "shell.execute_reply": "2026-07-14T15:58:24.033404Z",
+     "shell.execute_reply.started": "2026-07-14T15:58:23.589227Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate plot\n",
+    "plt.figure(figsize=(12, 5))\n",
+    "plt.axvspan(0, 360, color=\"k\", zorder=-1)\n",
+    "\n",
+    "# Plot the data\n",
+    "im = plt.imshow(\n",
+    "    filter_counts.T,\n",
+    "    cmap=\"twilight\",  # Set colormap\n",
+    "    norm=LogNorm(10, 1e3),  # Define limits of colormap\n",
+    "    extent=[0, 360, -90, 90],  # Set the limits of the data\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "\n",
+    "plt.colorbar(im, label=\"Observation Counts\", extend=\"both\")\n",
+    "\n",
+    "# Set axes limits\n",
+    "plt.xlim(0, 360)\n",
+    "plt.ylim(-90, 90)\n",
+    "\n",
+    "# Add labels to plot\n",
+    "plt.title(\"Observations of the Sky - HST\")\n",
+    "plt.xlabel(\"Right Ascension (degrees)\")\n",
+    "plt.ylabel(\"Declination (degrees)\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's an example of one mission, `HST`, that observes part of the region, though faint. Other missions that also give results in the missing `TESS` field are `SDSS`,`JWST`, and even `GALEX`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 2: Solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:58:31.926606Z",
+     "iopub.status.busy": "2026-07-14T15:58:31.925836Z",
+     "iopub.status.idle": "2026-07-14T15:58:31.941511Z",
+     "shell.execute_reply": "2026-07-14T15:58:31.938365Z",
+     "shell.execute_reply.started": "2026-07-14T15:58:31.926556Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Function to Query the Data\n",
+    "def query_instru_data(instrument): \n",
+    "    # Empty list to store data\n",
+    "    ra_coords = []\n",
+    "    dec_coords = []\n",
+    "\n",
+    "    page = 1\n",
+    "\n",
+    "    while True:\n",
+    "        data = Observations.query_criteria(instrument_name = instrument, # Column for instrument name\n",
+    "                                           pagesize = 1000,\n",
+    "                                           page = page)\n",
+    "        if len(data) == 0:\n",
+    "            print(\"Done\")\n",
+    "            break\n",
+    "\n",
+    "        ra_coords.extend(float(i) for i in data[\"s_ra\"]) # Convert into floats\n",
+    "        dec_coords.extend(float(i) for i in data[\"s_dec\"])\n",
+    "\n",
+    "        print(f\"Fetched page {page} with {len(data)} rows\")\n",
+    "\n",
+    "        page = page + 1\n",
+    "\n",
+    "    return ra_coords, dec_coords"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:59:13.141341Z",
+     "iopub.status.busy": "2026-07-14T15:59:13.140546Z",
+     "iopub.status.idle": "2026-07-14T16:00:31.043197Z",
+     "shell.execute_reply": "2026-07-14T16:00:31.042771Z",
+     "shell.execute_reply.started": "2026-07-14T15:59:13.141294Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Call function\n",
+    "filter_ra_coords, filter_dec_coords = query_instru_data('UVOT') # For this, I've used the UVOT (Ultraviolet/Optical Telescope)\n",
+    "\n",
+    "# Convert into array\n",
+    "filter_ra_coords = np.array(filter_ra_coords)\n",
+    "filter_dec_coords = np.array(filter_dec_coords)\n",
+    "\n",
+    "# Bin into 2D grid count\n",
+    "filter_counts, ra_edges, dec_edges = np.histogram2d(filter_ra_coords, \n",
+    "                                                    filter_dec_coords, \n",
+    "                                                    bins = [2100, 1050], \n",
+    "                                                    range = [[0, 360], [-90, 90]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T16:03:35.151105Z",
+     "iopub.status.busy": "2026-07-14T16:03:35.150306Z",
+     "iopub.status.idle": "2026-07-14T16:03:35.586251Z",
+     "shell.execute_reply": "2026-07-14T16:03:35.585818Z",
+     "shell.execute_reply.started": "2026-07-14T16:03:35.151052Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate plot\n",
+    "plt.figure(figsize=(12, 5))\n",
+    "plt.axvspan(0, 360, color=\"k\", zorder=-1)\n",
+    "\n",
+    "# Plot the data\n",
+    "im = plt.imshow(\n",
+    "    filter_counts.T,\n",
+    "    cmap=\"cool\",  # Set colormap\n",
+    "    norm=LogNorm(10, 1e3),  # Define limits of colormap\n",
+    "    extent=[0, 360, -90, 90],  # Set the limits of the data\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "\n",
+    "plt.colorbar(im, label=\"Observation Counts\", extend=\"both\")\n",
+    "\n",
+    "# Set axes limits\n",
+    "plt.xlim(0, 360)\n",
+    "plt.ylim(-90, 90)\n",
+    "\n",
+    "# Add labels to plot\n",
+    "plt.title(\"Observations of the Sky (UVOT)\")\n",
+    "plt.xlabel(\"Right Ascension (degrees)\")\n",
+    "plt.ylabel(\"Declination (degrees)\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Other Interesting Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T15:30:11.112571Z",
+     "iopub.status.busy": "2026-07-14T15:30:11.111804Z",
+     "iopub.status.idle": "2026-07-14T15:30:11.126352Z",
+     "shell.execute_reply": "2026-07-14T15:30:11.124489Z",
+     "shell.execute_reply.started": "2026-07-14T15:30:11.112516Z"
+    }
+   },
+   "source": [
+    "This is what it would look like if we filtered based on the **Kepler** mission!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T17:00:15.993315Z",
+     "iopub.status.busy": "2026-07-14T17:00:15.992730Z",
+     "iopub.status.idle": "2026-07-14T17:01:22.530575Z",
+     "shell.execute_reply": "2026-07-14T17:01:22.529940Z",
+     "shell.execute_reply.started": "2026-07-14T17:00:15.993282Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "filter_ra_coords, filter_dec_coords = query_mission_data('Kepler')\n",
+    "\n",
+    "filter_ra_coords = np.array(filter_ra_coords)\n",
+    "filter_dec_coords = np.array(filter_dec_coords)\n",
+    "\n",
+    "filter_counts, ra_edges, dec_edges = np.histogram2d(filter_ra_coords, \n",
+    "                                                    filter_dec_coords, \n",
+    "                                                    bins = [2100, 1050], \n",
+    "                                                    range = [[0, 360], [-90, 90]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T17:01:22.531105Z",
+     "iopub.status.busy": "2026-07-14T17:01:22.531016Z",
+     "iopub.status.idle": "2026-07-14T17:01:22.903908Z",
+     "shell.execute_reply": "2026-07-14T17:01:22.903398Z",
+     "shell.execute_reply.started": "2026-07-14T17:01:22.531097Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate plot\n",
+    "plt.figure(figsize=(12, 5))\n",
+    "plt.axvspan(0, 360, color=\"k\", zorder=-1)\n",
+    "\n",
+    "# Plot the data\n",
+    "im = plt.imshow(\n",
+    "    filter_counts.T,\n",
+    "    cmap=\"twilight\",  # Set colormap\n",
+    "    norm=LogNorm(10, 1e3),  # Define limits of colormap\n",
+    "    extent=[0, 360, -90, 90],  # Set the limits of the data\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "\n",
+    "plt.colorbar(im, label=\"Observation Counts\", extend=\"both\")\n",
+    "\n",
+    "# Set axes limits\n",
+    "plt.xlim(0, 360)\n",
+    "plt.ylim(-90, 90)\n",
+    "\n",
+    "# Add labels to plot\n",
+    "plt.title(\"Observations of the Sky - Kepler\")\n",
+    "plt.xlabel(\"Right Ascension (degrees)\")\n",
+    "plt.ylabel(\"Declination (degrees)\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, this is what it would look like if we filtered based on the **K2** mission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "execution": {
+     "iopub.execute_input": "2026-07-14T17:01:22.904216Z",
+     "iopub.status.busy": "2026-07-14T17:01:22.904141Z",
+     "iopub.status.idle": "2026-07-14T17:03:59.131940Z",
+     "shell.execute_reply": "2026-07-14T17:03:59.131505Z",
+     "shell.execute_reply.started": "2026-07-14T17:01:22.904209Z"
+    },
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "filter_ra_coords, filter_dec_coords = query_mission_data('K2')\n",
+    "\n",
+    "filter_ra_coords = np.array(filter_ra_coords)\n",
+    "filter_dec_coords = np.array(filter_dec_coords)\n",
+    "\n",
+    "filter_counts, ra_edges, dec_edges = np.histogram2d(filter_ra_coords, \n",
+    "                                                    filter_dec_coords, \n",
+    "                                                    bins = [2100, 1050], \n",
+    "                                                    range = [[0, 360], [-90, 90]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T17:04:04.489489Z",
+     "iopub.status.busy": "2026-07-14T17:04:04.488845Z",
+     "iopub.status.idle": "2026-07-14T17:04:04.909098Z",
+     "shell.execute_reply": "2026-07-14T17:04:04.908688Z",
+     "shell.execute_reply.started": "2026-07-14T17:04:04.489448Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate plot\n",
+    "plt.figure(figsize=(12, 5))\n",
+    "plt.axvspan(0, 360, color=\"k\", zorder=-1)\n",
+    "\n",
+    "# Plot the data\n",
+    "im = plt.imshow(\n",
+    "    filter_counts.T,\n",
+    "    cmap=\"twilight\",  # Set colormap\n",
+    "    norm=LogNorm(10, 1e3),  # Define limits of colormap\n",
+    "    extent=[0, 360, -90, 90],  # Set the limits of the data\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "\n",
+    "plt.colorbar(im, label=\"Observation Counts\", extend=\"both\")\n",
+    "\n",
+    "# Set axes limits\n",
+    "plt.xlim(0, 360)\n",
+    "plt.ylim(-90, 90)\n",
+    "\n",
+    "# Add labels to plot\n",
+    "plt.title(\"Observations of the Sky - K2\")\n",
+    "plt.xlabel(\"Right Ascension (degrees)\")\n",
+    "plt.ylabel(\"Declination (degrees)\")\n",
     "\n",
     "plt.show()"
    ]
@@ -1007,9 +2092,9 @@
    "source": [
     "### About This Notebook\n",
     "\n",
-    "**Authors:** Julie Imig (jimig@stsci.edu), Thomas Dutkiewicz (tdutkiewicz@stsci.edu)<br>\n",
+    "**Authors:** Julie Imig (jimig@stsci.edu), Thomas Dutkiewicz (tdutkiewicz@stsci.edu), Kailan Li (kli@stsci.edu)<br>\n",
     "**Keywords:** Tutorial, MAST, data visualization <br>\n",
-    "**Last Updated:** July 2025 <br>\n",
+    "**Last Updated:** July 2026 <br>\n",
     "\n",
     "***\n",
     "[Top of Page](#top)\n",
@@ -1019,21 +2104,12 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
+   "display_name": "SQL",
+   "language": "sql",
+   "name": "sql-notebook"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "name": "sql"
   }
  },
  "nbformat": 4,

--- a/notebooks/Visualizations/mast_sky/mast_sky.ipynb
+++ b/notebooks/Visualizations/mast_sky/mast_sky.ipynb
@@ -245,7 +245,7 @@
     "# Define a custom color map\n",
     "# This will create a gradient from black to blue to white!\n",
     "colormap = LinearSegmentedColormap.from_list(\n",
-    "    \"\", [\"black\", \"midnightblue\", \"#1a619f\", \"skyblue\", \"white\"]\n",
+    "    \"\", [\"black\", \"midnightblue\", \"#1a619f\", \"deepskyblue\", \"white\"]\n",
     ")\n",
     "\n",
     "# Plot the data\n",
@@ -843,7 +843,7 @@
    "source": [
     "## Wallpaper Image\n",
     "\n",
-    "Just for fun, let's make a pretty version of this plot to use as a Desktop Wallpaper, removing the axes and labels and focusing on the image. Please download the image from the repository before you begin."
+    "Just for fun, let's make a pretty version of this plot to use as a Desktop Wallpaper, removing the axes and labels and focusing on the image. Please download the logo from the repository before you begin."
    ]
   },
   {
@@ -877,7 +877,7 @@
     ")\n",
     "\n",
     "# Add MAST logo to corner\n",
-    "mast_logo = imread(\"MAST-Logo-Horizontal.png\")\n",
+    "mast_logo = imread(\"imgs/MAST-Logo-Horizontal.png\")\n",
     "# preserve aspect ratio so the logo isn't skewed\n",
     "mast_logo_ratio = mast_logo.shape[0] / mast_logo.shape[1] * (8 / 9)\n",
     "# Need extra 8/9 because the figure size is 16:9 but the pixel size is 16:8\n",
@@ -951,7 +951,7 @@
     "\n",
     "\n",
     "# Add MAST logo to corner\n",
-    "mast_logo = imread(\"MAST-Logo-Horizontal.png\")\n",
+    "mast_logo = imread(\"imgs/MAST-Logo-Horizontal.png\")\n",
     "# preserve aspect ratio so the logo isn't skewed\n",
     "mast_logo_ratio = mast_logo.shape[0] / mast_logo.shape[1] * (8 / 9)\n",
     "# Need extra 8/9 because the figure size is 16:9 but the pixel size is 16:8\n",

--- a/notebooks/Visualizations/mast_sky/mast_sky.ipynb
+++ b/notebooks/Visualizations/mast_sky/mast_sky.ipynb
@@ -1225,7 +1225,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "execution": {
      "iopub.execute_input": "2026-07-14T15:35:53.333018Z",
      "iopub.status.busy": "2026-07-14T15:35:53.332151Z",
@@ -1235,8 +1234,7 @@
     },
     "jupyter": {
      "outputs_hidden": true
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1442,8 +1440,7 @@
      "iopub.status.idle": "2026-07-14T15:47:06.642952Z",
      "shell.execute_reply": "2026-07-14T15:47:06.641712Z",
      "shell.execute_reply.started": "2026-07-14T15:47:06.595622Z"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1508,7 +1505,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "execution": {
      "iopub.execute_input": "2026-07-14T15:47:11.593286Z",
      "iopub.status.busy": "2026-07-14T15:47:11.592447Z",
@@ -1518,8 +1514,7 @@
     },
     "jupyter": {
      "outputs_hidden": true
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1706,8 +1701,7 @@
      "iopub.status.idle": "2026-07-14T15:57:48.978815Z",
      "shell.execute_reply": "2026-07-14T15:57:48.978397Z",
      "shell.execute_reply.started": "2026-07-14T15:51:51.425110Z"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1831,8 +1825,7 @@
      "iopub.status.idle": "2026-07-14T16:00:31.043197Z",
      "shell.execute_reply": "2026-07-14T16:00:31.042771Z",
      "shell.execute_reply.started": "2026-07-14T15:59:13.141294Z"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1923,8 +1916,7 @@
      "iopub.status.idle": "2026-07-14T17:01:22.530575Z",
      "shell.execute_reply": "2026-07-14T17:01:22.529940Z",
      "shell.execute_reply.started": "2026-07-14T17:00:15.993282Z"
-    },
-    "scrolled": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1991,7 +1983,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "execution": {
      "iopub.execute_input": "2026-07-14T17:01:22.904216Z",
      "iopub.status.busy": "2026-07-14T17:01:22.904141Z",

--- a/notebooks/Visualizations/mast_sky/mast_sky.ipynb
+++ b/notebooks/Visualizations/mast_sky/mast_sky.ipynb
@@ -1724,7 +1724,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (ipykernel)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/Visualizations/mast_sky/mast_sky.ipynb
+++ b/notebooks/Visualizations/mast_sky/mast_sky.ipynb
@@ -1724,9 +1724,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (mywork)",
+   "display_name": "Python (ipykernel)",
    "language": "python",
-   "name": "mywork"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1738,7 +1738,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I added in a section at the bottom to query results from Astroquery based on a specific instrument, mission, or filter. Then, I binned the results into a 2D grid count and copied the previous code to display an image for the user. Additionally, I've also added two exercises for the user to practice creating their own images based on different filters. 