### PR TITLE
Add environment variable to prevent nbval timeouts on jdaviz in sidecars

### DIFF
--- a/.github/workflows/fornax_branch_deploy.yml
+++ b/.github/workflows/fornax_branch_deploy.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  build:
+    env:
+      JDAVIZ_SKIP_DISPLAY: true  # prevents nbval timeouts with jdaviz in sidecar
   deploy_notebooks:
     name: Deploy deploy_to_fornax branch
     runs-on: ubuntu-latest

--- a/.github/workflows/notebook-merge.yml
+++ b/.github/workflows/notebook-merge.yml
@@ -19,6 +19,9 @@ on:
       - '*.js'
 
 jobs:
+  build:
+    env:
+      JDAVIZ_SKIP_DISPLAY: true                     # prevents nbval timeouts with jdaviz in sidecar
   notebook-ci-and-deploy:
     uses: spacetelescope/notebook-ci-actions/.github/workflows/notebook-ci-unified.yml@v1
     with:

--- a/.github/workflows/notebook-on-demand.yml
+++ b/.github/workflows/notebook-on-demand.yml
@@ -52,6 +52,9 @@ on:
         default: false
 
 jobs:
+  build:
+    env:
+      JDAVIZ_SKIP_DISPLAY: true  # prevents nbval timeouts with jdaviz in sidecar
   validate-all:
     if: inputs.action_type == 'validate-all'
     uses:  spacetelescope/notebook-ci-actions/.github/workflows/notebook-ci-unified.yml@v1

--- a/.github/workflows/notebook-pr.yml
+++ b/.github/workflows/notebook-pr.yml
@@ -18,6 +18,9 @@ on:
       - '*.js'
 
 jobs:
+  build:
+    env:
+      JDAVIZ_SKIP_DISPLAY: true                 # prevents nbval timeouts with jdaviz in sidecar
   notebook-ci:
     uses: spacetelescope/notebook-ci-actions/.github/workflows/notebook-ci-unified.yml@v1
     with:

--- a/.github/workflows/notebook-scheduled.yml
+++ b/.github/workflows/notebook-scheduled.yml
@@ -9,6 +9,9 @@ on:
     - cron: '0 2 * * 0'
           
 jobs:
+  build:
+    env:
+      JDAVIZ_SKIP_DISPLAY: true  # prevents nbval timeouts with jdaviz in sidecar
   execute-all:  
     uses: spacetelescope/notebook-ci-actions/.github/workflows/notebook-ci-unified.yml@v1
     with:


### PR DESCRIPTION
Displaying jdaviz in a sidecar can leave the frontend `{'execution_state': 'busy'}`, which causes timeout failures in CI with [spacetelescope/notebook-ci-actions](https://github.com/spacetelescope/notebook-ci-actions/), since [nbval](https://github.com/computationalmodelling/nbval) listens for the jupyter kernel `{'execution_state': 'idle'}` before executing the next cell. Since that message isn't sent, cells calling `jd.show` within a sidecar will timeout. 

In this PR, I've added an environment variable `JDAVIZ_SKIP_DISPLAY` to each of the github actions that use `spacetelescope/notebook-ci-actions/.github/workflows/notebook-ci-unified.yml@v1`. If the environment variable exists and is true, jdaviz will skip calls to `display` (implemented in https://github.com/spacetelescope/jdaviz/pull/4294), which unblocks Cobalt notebook contributions to `mast_notebooks` with jdaviz, specifically https://github.com/spacetelescope/mast_notebooks/pull/163. 