### PR TITLE
Correct RITA download to use requests.get

### DIFF
--- a/notebooks/Roman/CaSSI_RITA_Retrieval/cassi_rita_query_download_script.py
+++ b/notebooks/Roman/CaSSI_RITA_Retrieval/cassi_rita_query_download_script.py
@@ -148,7 +148,7 @@ def download_cassi_file(
     # Payload header:
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f'token {token}'
+        "Authorization": f'Bearer {token}'
     }
 
     payload = {"product_url": product_url}
@@ -166,7 +166,7 @@ def download_cassi_file(
             if verbose:
                 print(f"{thread_label} Downloading {filename}...")
 
-            response = requests.post(
+            response = requests.get(
                 endpoint_url,
                 headers=headers,
                 json=payload,
@@ -607,7 +607,7 @@ def query_cassi_general(
 
     # Set headers with authentication
     headers = {
-        "Authorization": f"token {token}",
+        "Authorization": f"Bearer {token}",
         "Content-Type": "application/json"
     }
 


### PR DESCRIPTION
Correct the RITA download script to use requests.get(), as the previously the download API request was using requests.post().

Target to merge to the roman-prelaunch branch, for supporting Roman commissioning.