### PR TITLE
Fix link formatting in catalog access notebook

### DIFF
--- a/notebooks/Roman/Catalog_Access_Data_Quality_Cuts/catalog_access_data_quality_cuts.ipynb
+++ b/notebooks/Roman/Catalog_Access_Data_Quality_Cuts/catalog_access_data_quality_cuts.ipynb
@@ -67,7 +67,7 @@
     "- [*astropy.units*](https://docs.astropy.org/en/stable/units/index.html) to specify angular units\n",
     "- [*numpy*](https://numpy.org/doc/stable/) for numerical calculations\n",
     "- [*matplotlib.pyplot*](https://matplotlib.org/stable/) for plotting catalog data\n",
-    "- [*mast_aladin*](github.com/spacetelescope/mast-aladin) to view targets on the sky\n",
+    "- [*mast_aladin*](https://github.com/spacetelescope/mast-aladin) to view targets on the sky\n",
     "- [*sidecar Sidecar*](https://github.com/jupyter-widgets/jupyterlab-sidecar) to display MAST-Aladin alongside the notebook\n",
     "- *time* to enable time delays when flipping through objects with MAST-Aladin\n",
     "- [*astropy.table Table*](https://docs.astropy.org/en/stable/table/index.html) to construct tables from flag values\n",

--- a/notebooks/Roman/Catalog_Access_Data_Quality_Cuts/catalog_access_data_quality_cuts.ipynb
+++ b/notebooks/Roman/Catalog_Access_Data_Quality_Cuts/catalog_access_data_quality_cuts.ipynb
@@ -123,7 +123,7 @@
     "\n",
     "#### Querying the PanSTARRS catalog\n",
     "\n",
-    "First, we consult the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs) and the MAST Catalog Schema Browser](https://mast.stsci.edu/schema_browser/#/ps1_dr2/mean_object) to investigate the available tables and columns.\n",
+    "First, we consult the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs) and the [MAST Catalog Schema Browser](https://mast.stsci.edu/schema_browser/#/ps1_dr2/mean_object) to investigate the available tables and columns.\n",
     "\n",
     "We determine that we can obtain all necessary information from the PanSTARRS DR2 \"mean\" table, which we can access using [`astroquery.mast`](https://astroquery.readthedocs.io/en/latest/mast/mast_catalog.html).\n",
     "\n",


### PR DESCRIPTION
Current version misses the opening "[", so the notebook doesn't render the link correctly (see below)
<img width="885" height="165" alt="image" src="https://github.com/user-attachments/assets/8ee98428-c4dd-408d-be19-24eff2c96653" />
